### PR TITLE
correcting data types in create space documentation

### DIFF
--- a/docs/source/use_op/op_space.rst
+++ b/docs/source/use_op/op_space.rst
@@ -19,12 +19,12 @@ Create Space
           },
           "fku": {
               "type": "integer",
-              "index":"false"
+              "index": false
           },
           "tags": {
               "type": "keyword",
-              "array":true,
-              "index":"true"
+              "array": true,
+              "index": true
           },
           "image_vec": {
               "type": "vector",


### PR DESCRIPTION
Updating the docs so to reflect the boolean data types associated with the "index" field. In the current documentation, there is a mix of boolean and string. [Per Issue 91](https://github.com/vearch/vearch/issues/91), vearch will throw a datatype error if not a boolean.

The updated file in master and in this PR is slightly different than the one on readthedocs [op space](https://vearch.readthedocs.io/en/latest/use_op/op_space.html).