### PR TITLE
Update client.go

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1037,8 +1037,11 @@ func GetSource(doc *vearchpb.ResultItem, space *entity.Space, idIsLong bool, sor
 			SortName: "_score",
 		})
 	}
-
-	marshal, err := json.Marshal(source)
+        var marshal []byte
+	var err error
+	if len(source) > 0 {
+	    marshal, err = json.Marshal(source)
+	}
 	if err != nil {
 		return nil, sortValues, pKey, err
 	}


### PR DESCRIPTION
修改当检索没有设置需要返回的filed字段是，不需要进行json化，该场景在 batch128的top512检索的场景 tps相差几百。