### PR TITLE
Update schedule_job.go

### DIFF
--- a/master/schedule_job.go
+++ b/master/schedule_job.go
@@ -63,7 +63,6 @@ func walkSpaces(masterServer *Server, spaces []*entity.Space) {
 	ctx := masterServer.ctx
 	log.Info("Start Walking Spaces!")
 	for _, space := range spaces {
-		spaceChannel <- space
 		if db, err := masterServer.client.Master().Get(ctx, entity.DBKeyBody(space.DBId)); err != nil {
 			log.Error("Failed to find database contains space,SpaceName:", space.Name, " SpaceID:", space.Id, " err:", err)
 		} else if db == nil {


### PR DESCRIPTION
fix: clean up the wrong partition, space and server information on every 60 seconds. It will only be executed once when start or restarting. A bufferless channel is blocked in walkspaces .