### PR TITLE
[TicketNo:]fix has_boost bug

### DIFF
--- a/router/document/doc_query.go
+++ b/router/document/doc_query.go
@@ -633,8 +633,11 @@ func (query *VectorQuery) ToC(retrievalType string) (*vearchpb.VectorQuery, erro
 		}
 	}
 
+	var has_boost int32 = 1
+
 	if query.Boost == nil {
 		query.Boost = defaultBoost
+		has_boost = 0
 	}
 
 	vectorQuery := &vearchpb.VectorQuery{
@@ -643,7 +646,7 @@ func (query *VectorQuery) ToC(retrievalType string) (*vearchpb.VectorQuery, erro
 		MinScore: *query.MinScore,
 		MaxScore: *query.MaxScore,
 		Boost:    *query.Boost,
-		HasBoost: 0,
+		HasBoost: has_boost,
 	}
 	return vectorQuery, nil
 }


### PR DESCRIPTION
[Description:]The boost parameter is invalid when the curl mode is used.