### PR TITLE
Build docker container that includes libzfp

### DIFF
--- a/cloud/compile.sh
+++ b/cloud/compile.sh
@@ -4,4 +4,4 @@
 git submodule init
 git submodule update
 
-docker run -v $(dirname "$PWD"):/vearch vearch/vearch_env:3.2.5 /vearch/cloud/compile/compile.sh
+docker run -it -v $(dirname "$PWD"):/vearch vearch/vearch_env:3.2.5 /vearch/cloud/compile/compile.sh

--- a/cloud/compile/compile.sh
+++ b/cloud/compile/compile.sh
@@ -18,5 +18,6 @@ mkdir -p /vearch/build/lib/
 cp /env/app/faiss_install/lib/libfaiss.so /vearch/build/lib/
 cp /env/app/rocksdb_install/lib/librocksdb.* /vearch/build/lib/
 cp /vearch/build/gamma_build/libgamma.* /vearch/build/lib/
+cp /usr/local/lib64/libzfp.so /vearch/build/lib/
 
 rm -rf /vearch/build/gamma_build

--- a/cloud/compile/compile.sh
+++ b/cloud/compile/compile.sh
@@ -18,6 +18,6 @@ mkdir -p /vearch/build/lib/
 cp /env/app/faiss_install/lib/libfaiss.so /vearch/build/lib/
 cp /env/app/rocksdb_install/lib/librocksdb.* /vearch/build/lib/
 cp /vearch/build/gamma_build/libgamma.* /vearch/build/lib/
-cp /usr/local/lib64/libzfp.so /vearch/build/lib/
+cp /usr/local/lib64/libzfp.* /vearch/build/lib/
 
 rm -rf /vearch/build/gamma_build


### PR DESCRIPTION
otherwise, we would get an error 
```
seki@ubuntu20:~/vearch/cloud$ docker run vearch/vearch:3.2.5
/vearch/bin/vearch: error while loading shared libraries: libzfp.so.0: cannot open shared object file: No such file or directory
```