### PR TITLE
fix wrong error code if ps not found

### DIFF
--- a/client/master.go
+++ b/client/master.go
@@ -132,7 +132,7 @@ func (m *masterClient) QueryServer(ctx context.Context, id entity.NodeID) (*enti
 	}
 	if bytes == nil {
 		log.Error("server can not find on master, maybe server is offline, nodeId:[%d]", id)
-		return nil, vearchpb.NewError(vearchpb.ErrorEnum_PARTITION_NOT_EXIST, nil)
+		return nil, vearchpb.NewError(vearchpb.ErrorEnum_PS_NOTEXISTS, nil)
 	}
 
 	p := new(entity.Server)


### PR DESCRIPTION
If PS node cannot be found on master, the return error enum should be PS_NOTEXISTS rather than PARTITION_NOT_EXIST.