### PR TITLE
FIX: the last file sync is not complete, only the first chunk synced

### DIFF
--- a/ps/engine/gammacb/snapshot.go
+++ b/ps/engine/gammacb/snapshot.go
@@ -35,7 +35,7 @@ type GammaSnapshot struct {
 func (g *GammaSnapshot) Next() ([]byte, error) {
 	var err error
 	defer errutil.CatchError(&err)
-	if int(g.index) >= len(g.absFileNames) {
+	if int(g.index) >= len(g.absFileNames) && g.size == 0 {
 		log.Debug("leader send over, leader finish snapshot.")
 		snapShotMsg := &vearchpb.SnapshotMsg{
 			Status: vearchpb.SnapshotStatus_Finish,


### PR DESCRIPTION
This PR fixed the problem of snapshot files sync. If the last file size exceeds the chunk size, only the first chunk is synced.