### PR TITLE
fix: exclude leader replica when client_type is not_leader

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -708,7 +708,7 @@ func GetNodeIdsByClientType(clientType string, partition *entity.Partition, serv
 					noLeaderIDs = append(noLeaderIDs, nodeID)
 				}
 			} else {
-				if serverExist {
+				if serverExist && nodeID != partition.LeaderID {
 					noLeaderIDs = append(noLeaderIDs, nodeID)
 				}
 			}


### PR DESCRIPTION
If `RaftConsistent` configuration is `false`, the leader replica is not excluded under `not_leader` case.