### PR TITLE
fix too many "leader send over, leader finish snapshot" logs

### DIFF
--- a/ps/engine/gammacb/snapshot.go
+++ b/ps/engine/gammacb/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vearch/vearch/util/errutil"
 	"github.com/vearch/vearch/util/fileutil"
 	"github.com/vearch/vearch/util/log"
+	"io"
 	"io/ioutil"
 	"math"
 	"os"
@@ -40,7 +41,12 @@ func (g *GammaSnapshot) Next() ([]byte, error) {
 		snapShotMsg := &vearchpb.SnapshotMsg{
 			Status: vearchpb.SnapshotStatus_Finish,
 		}
-		return protobuf.Marshal(snapShotMsg)
+		data, err := protobuf.Marshal(snapShotMsg)
+		if err != nil {
+			return data, err
+		} else {
+			return data, io.EOF
+		}
 	}
 	if g.reader == nil {
 		filePath := g.absFileNames[g.index]
@@ -133,7 +139,7 @@ func (ge *gammaEngine) ApplySnapshot(peers []proto.Peer, iter proto.SnapIterator
 	var out *os.File
 	for {
 		bs, err := iter.Next()
-		if err != nil {
+		if err != nil && err != io.EOF {
 			errutil.ThrowError(err)
 			return err
 		}


### PR DESCRIPTION
change_member api is used to add a replica. When snapshot is finished, there are many repeated logs "leader send over, leader finish snapshot" on leader node as following

```
DEBUG 2021-05-18 14:53:47,940 snapshot.go:75 current g.size [53760030], info size [10240000]
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,011 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
DEBUG 2021-05-18 14:53:48,012 snapshot.go:39 leader send over, leader finish snapshot.
...
```

The reason is described in this PR [fix: when sending snapshot, snapshot.Next iterates forever until raft error](https://github.com/tiglabs/raft/pull/23)

This PR fixes this problem. 