### PR TITLE
fix can't delete by negative-id

### DIFF
--- a/util/regularutil/string_check.go
+++ b/util/regularutil/string_check.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	number_pattern = "^[0-9]*$"
+	number_pattern = "^[-+]?\\d+$"
 )
 
 func StringCheckNum(input string) bool {


### PR DESCRIPTION
if item's id is a negative number, delete item will be failed
cause: regular expression not test ‘-’