### PR TITLE
search replica using round robin instead of random strategy

### DIFF
--- a/client/round_robin.go
+++ b/client/round_robin.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"github.com/vearch/vearch/proto/entity"
+	"github.com/vearch/vearch/util/atomic"
+	"sync"
+)
+
+type ReplicaRoundRobin struct {
+	// key: partition id, value: atomic counter
+	counterMap sync.Map
+}
+
+func NewReplicaRoundRobin() *ReplicaRoundRobin {
+	return &ReplicaRoundRobin{}
+}
+
+func (rr *ReplicaRoundRobin) Next(pid entity.PartitionID, replicas []entity.NodeID) entity.NodeID {
+	if len(replicas) <= 0 {
+		return 0
+	}
+
+	var ix uint64
+	counter, ok := rr.counterMap.LoadOrStore(pid, atomic.NewCounter(1))
+	if ok {
+		// loaded
+		newValue := counter.(*atomic.AtomicCounter).Incr()
+		ix = (newValue - 1) % uint64(len(replicas))
+	}
+	return replicas[ix]
+}

--- a/util/atomic/atomic_counter.go
+++ b/util/atomic/atomic_counter.go
@@ -1,0 +1,31 @@
+package atomic
+
+import "sync/atomic"
+
+type AtomicCounter struct {
+	v uint64
+}
+
+func NewCounter(initial uint64) *AtomicCounter {
+	return &AtomicCounter{v: initial}
+}
+
+func (c *AtomicCounter) Incr() uint64 {
+	return atomic.AddUint64(&c.v, 1)
+}
+
+func (c *AtomicCounter) Decr() uint64 {
+	return atomic.AddUint64(&c.v, ^uint64(0))
+}
+
+func (c *AtomicCounter) Add(v uint64) uint64 {
+	return atomic.AddUint64(&c.v, v)
+}
+
+func (c *AtomicCounter) Get() uint64 {
+	return atomic.LoadUint64(&c.v)
+}
+
+func (c *AtomicCounter) CompareAndSwap(o, n uint64) bool {
+	return atomic.CompareAndSwapUint64(&c.v, o, n)
+}


### PR DESCRIPTION
The random strategy can cause unbalanced replica search load. Our test shows that rr can increase about 20% QPS compared to random strategy.