### PR TITLE
support router and ps resource isolation by resource name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -158,6 +158,7 @@ type Base struct {
 type GlobalCfg struct {
 	Base
 	Name            string `toml:"name,omitempty" json:"name"`
+	ResourceName    string `toml:"resource_name,omitempty" json:"resource_name"`
 	Signkey         string `toml:"signkey,omitempty" json:"signkey"`
 	SkipAuth        bool   `toml:"skip_auth,omitempty" json:"skip_auth"`
 	SelfManageEtcd  bool   `toml:"self_manage_etcd,omitempty" json:"self_manage_etcd"`
@@ -285,7 +286,7 @@ type RouterCfg struct {
 	CloseTimeout  int64    `toml:"close_timeout" json:"close_timeout"`
 	RouterIPS     []string `toml:"router_ips" json:"router_ips"`
 	ConcurrentNum int      `toml:"concurrent_num" json:"concurrent_num"`
-	RpcTimeOut    int      `toml:"rpc_timeout" json:"rpc_timeout"`  //ms
+	RpcTimeOut    int      `toml:"rpc_timeout" json:"rpc_timeout"` //ms
 }
 
 func (routerCfg *RouterCfg) ApiUrl(keyNumber int) string {

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -1,6 +1,8 @@
 [global]
     # the name will validate join cluster by same name
     name = "cbdb"
+    # specify which resources to use to create space
+    resource_name = "vector_db1"
     # you data save to disk path ,If you are in a production environment, You'd better set absolute paths
     data = ["datas/","datas1/"]
     # log path , If you are in a production environment, You'd better set absolute paths

--- a/master/cluster_api.go
+++ b/master/cluster_api.go
@@ -45,11 +45,12 @@ import (
 )
 
 const (
-	DB            = "db"
-	dbName        = "db_name"
-	spaceName     = "space_name"
-	headerAuthKey = "Authorization"
-	NodeID        = "node_id"
+	DB                  = "db"
+	dbName              = "db_name"
+	spaceName           = "space_name"
+	headerAuthKey       = "Authorization"
+	NodeID              = "node_id"
+	DefaultResourceName = "default"
 )
 
 type clusterAPI struct {
@@ -277,6 +278,11 @@ func (ca *clusterAPI) createSpace(c *gin.Context) {
 		log.Error("parse space settings err: %v", err)
 		ginutil.NewAutoMehtodName(c).SendJsonHttpReplyError(err)
 		return
+	}
+
+	// set default resource name
+	if space.ResourceName == "" {
+		space.ResourceName = DefaultResourceName
 	}
 
 	if space.PartitionNum <= 0 {

--- a/master/cluster_service.go
+++ b/master/cluster_service.go
@@ -334,7 +334,8 @@ func (ms *masterService) createSpaceService(ctx context.Context, dbName string, 
 	}
 
 	if int(space.ReplicaNum) > len(serverPartitions) {
-		return fmt.Errorf("not enough PS , need replica %d but only has %d", int(space.ReplicaNum), len(servers))
+		return fmt.Errorf("not enough PS , need replica %d but only has %d",
+			int(space.ReplicaNum), len(serverPartitions))
 	}
 
 	space.Enabled = util.PBool(false)
@@ -505,6 +506,10 @@ func (ms *masterService) filterAndSortServer(ctx context.Context, space *entity.
 
 	if psMap == nil { //means only use public
 		for i, s := range servers {
+			// only resourceName equal can use
+			if s.ResourceName != space.ResourceName {
+				continue
+			}
 			if !s.Private {
 				serverPartitions[i] = 0
 				serverIndex[s.ID] = i
@@ -512,6 +517,11 @@ func (ms *masterService) filterAndSortServer(ctx context.Context, space *entity.
 		}
 	} else { // only use define
 		for i, s := range servers {
+			// only resourceName equal can use
+			if s.ResourceName != space.ResourceName {
+				psMap[s.Ip] = false
+				continue
+			}
 			if psMap[s.Ip] {
 				serverPartitions[i] = 0
 				serverIndex[s.ID] = i

--- a/proto/entity/server.go
+++ b/proto/entity/server.go
@@ -28,6 +28,7 @@ type BuildVersion struct {
 //server/id:[body] ttl 3m 3s
 type Server struct {
 	ID                NodeID        `json:"name,omitempty"` //unique name for raft
+	ResourceName      string        `toml:"resource_name,omitempty" json:"resource_name"`
 	RpcPort           uint16        `json:"rpc_port"`
 	RaftHeartbeatPort uint16        `json:"raft_heartbeat_port"`
 	RaftReplicatePort uint16        `json:"raft_replicate_port"`
@@ -40,9 +41,9 @@ type Server struct {
 
 //FailServer /fail/server/id:[body] ttl 3m 3s
 type FailServer struct {
-	ID				  NodeID        `json:"nodeID,omitempty"` //unique name for raft
-	TimeStamp		  int64  		`json:"time_stamp,omitempty"`
-	Node			  *Server		`json:"server,omitempty"`
+	ID        NodeID  `json:"nodeID,omitempty"` //unique name for raft
+	TimeStamp int64   `json:"time_stamp,omitempty"`
+	Node      *Server `json:"server,omitempty"`
 }
 
 func (s *Server) RpcAddr() string {

--- a/proto/entity/space.go
+++ b/proto/entity/space.go
@@ -88,6 +88,7 @@ type RetrievalParam struct {
 type Space struct {
 	Id              SpaceID                     `json:"id,omitempty"`
 	Name            string                      `json:"name,omitempty"` //user setting
+	ResourceName    string                      `toml:"resource_name,omitempty" json:"resource_name"`
 	Version         Version                     `json:"version,omitempty"`
 	DBId            DBID                        `json:"db_id,omitempty"`
 	Enabled         *bool                       `json:"enabled"`    //Enabled flag whether the space can work

--- a/ps/schedule_job.go
+++ b/ps/schedule_job.go
@@ -35,6 +35,7 @@ func (s *Server) StartHeartbeatJob() {
 		server := &entity.Server{
 			ID:                s.nodeID,
 			Ip:                s.ip,
+			ResourceName:      config.Conf().Global.ResourceName,
 			RpcPort:           config.Conf().PS.RpcPort,
 			RaftHeartbeatPort: config.Conf().PS.RaftHeartbeatPort,
 			RaftReplicatePort: config.Conf().PS.RaftReplicatePort,

--- a/startup.go
+++ b/startup.go
@@ -54,10 +54,11 @@ func init() {
 }
 
 const (
-	psTag     = "ps"
-	masterTag = "master"
-	routerTag = "router"
-	allTag    = "all"
+	psTag               = "ps"
+	masterTag           = "master"
+	routerTag           = "router"
+	allTag              = "all"
+	DefaultResourceName = "default"
 )
 
 func main() {
@@ -75,6 +76,11 @@ func main() {
 	log.Info("The Config File Is: %v", confPath)
 
 	config.InitConfig(confPath)
+
+	if config.Conf().Global.ResourceName == "" {
+		config.Conf().Global.ResourceName = DefaultResourceName
+	}
+
 	if config.Conf().TracerCfg != nil {
 		closer := tracer.InitJaeger(config.Conf().Global.Name, config.Conf().TracerCfg)
 		defer closer.Close()


### PR DESCRIPTION
Router and PS can only be used with the same resource_name space
step1: ​set global config 
[global]
​# specify which resources to use to create space
   ​resource_name = "default" 
step2: ​create space
curl -XPUT -H "content-type: application/json" -d'
{
    "name": "space1",
    "partition_num": 1,
    "replica_num": 1,
    "resource_name":"default",
    "engine": {
      ...
    },
    "properties": {
      ...
    }
}
' http://master_server/space/$db_name/_create