### PR TITLE
修复HasBoost没有默认值报错问题

### DIFF
--- a/router/document/doc_query.go
+++ b/router/document/doc_query.go
@@ -63,6 +63,7 @@ type VectorQuery struct {
 	MinScore      *float64        `json:"min_score,omitempty"`
 	MaxScore      *float64        `json:"max_score,omitempty"`
 	RetrievalType string          `json:"retrieval_type"`
+	HasBoost      *int32          `json:"has_boost"`
 }
 
 var defaultBoost = util.PFloat64(1)
@@ -670,7 +671,7 @@ func (query *VectorQuery) ToC(retrievalType string) (*vearchpb.VectorQuery, erro
 		MinScore:      *query.MinScore,
 		MaxScore:      *query.MaxScore,
 		Boost:         *query.Boost,
-		HasBoost:      0,
+		HasBoost:      *query.HasBoost,
 		RetrievalType: retrievalType,
 	}
 	return vectorQuery, nil

--- a/router/document/doc_query.go
+++ b/router/document/doc_query.go
@@ -67,7 +67,7 @@ type VectorQuery struct {
 }
 
 var defaultBoost = util.PFloat64(1)
-var defaultHasBoost = util.PInt32(1)
+var defaultHasBoost = util.PInt32(0)
 
 var minOffset float64 = 0.0000001
 

--- a/router/document/doc_query.go
+++ b/router/document/doc_query.go
@@ -67,6 +67,7 @@ type VectorQuery struct {
 }
 
 var defaultBoost = util.PFloat64(1)
+var defaultHasBoost = util.PInt32(1)
 
 var minOffset float64 = 0.0000001
 
@@ -663,6 +664,10 @@ func (query *VectorQuery) ToC(retrievalType string) (*vearchpb.VectorQuery, erro
 
 	if query.Boost == nil {
 		query.Boost = defaultBoost
+	}
+
+	if query.HasBoost == nil {
+		query.HasBoost = defaultHasBoost
 	}
 
 	vectorQuery := &vearchpb.VectorQuery{


### PR DESCRIPTION
has_boost不填的情况下会报：runtime error:invalid memory address or nil pointer dereference
上次添加的时候没注意，(。・＿・。)ﾉI’m sorry~
![企业微信截图_541bd301-3ff7-4dea-99c9-78d7b320529f](https://github.com/vearch/vearch/assets/3123993/32ecbbab-8791-48e8-acae-4d8540cfc80e)
