### PR TITLE
Change shell from 'sh' to 'bash' in CMakeLists.txt for executing build.sh

### DIFF
--- a/internal/engine/CMakeLists.txt
+++ b/internal/engine/CMakeLists.txt
@@ -15,7 +15,7 @@ option(BUILD_THREAD_NUM "Build faiss thread num" 4)
 
 
 exec_program(
-    "sh"
+    "bash"
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party
     ARGS "build.sh" ${BUILD_WITH_GPU} ${BUILD_THREAD_NUM})
 

--- a/internal/engine/CMakeLists.txt
+++ b/internal/engine/CMakeLists.txt
@@ -197,7 +197,7 @@ endif()
 if(BUILD_WITH_SCANN)
     message(STATUS "With SCANN INDEX")
     exec_program(
-        "sh"
+        "bash"
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party
         ARGS "build-scann.sh"
         RETURN_VALUE EXEC_RET_VAL)


### PR DESCRIPTION
## Description
This PR updates the `exec_program` command in `CMakeLists.txt` to use `bash` instead of `sh` for running the `build.sh` script within the `third_party` directory, specifically tailored for Ubuntu systems.

## Reason
`build.sh` contains `bash`-specific syntax that may not be compatible with the standard `sh` shell on Ubuntu.

## Testing
Locally tested on Ubuntu to ensure `build.sh` runs correctly with `bash`.

Please merge if appropriate.

