### PR TITLE
fix: destory column family handle before close database

### DIFF
--- a/internal/engine/storage/storage_manager.cc
+++ b/internal/engine/storage/storage_manager.cc
@@ -145,6 +145,10 @@ Status StorageManager::Init(int cache_size) {
       return Status::IOError(s.ToString());
     }
 
+    for (auto cf_handle : cf_handles_) {
+      db_->DestroyColumnFamilyHandle(cf_handle);
+    }
+
     cf_handles_.clear();
     db_.reset();
   } else {


### PR DESCRIPTION
Before close rocksdb, destory created column family to avoid memory leak.