### PR TITLE
perf: add boundary checks and move semantics to ScalarIndexResult con…

### DIFF
--- a/internal/engine/table/bitmap_index.cc
+++ b/internal/engine/table/bitmap_index.cc
@@ -105,8 +105,8 @@ ScalarIndexResult BitmapIndex::BitmapToResult(const roaring::Roaring64Map& bitma
   return result;
 }
 
-ScalarIndexResult BitmapIndex::BitmapToResultWithOffsetLimit(const roaring::Roaring64Map& bitmap, int offset, int limit) {
-  ScalarIndexResult result(bitmap, offset, limit);
+ScalarIndexResult BitmapIndex::BitmapToResultWithOffsetLimit(roaring::Roaring64Map bitmap, int offset, int limit) {
+  ScalarIndexResult result(std::move(bitmap), offset, limit);
   return result;
 }
 

--- a/internal/engine/table/bitmap_index.h
+++ b/internal/engine/table/bitmap_index.h
@@ -64,7 +64,7 @@ class BitmapIndex : public ScalarIndex {
   ScalarIndexResult BitmapToResult(const roaring::Roaring64Map& bitmap);
 
   // Convert roaring::Roaring64Map to ScalarIndexResult with offset/limit
-  ScalarIndexResult BitmapToResultWithOffsetLimit(const roaring::Roaring64Map& bitmap, int offset, int limit);
+  ScalarIndexResult BitmapToResultWithOffsetLimit(roaring::Roaring64Map bitmap, int offset, int limit);
 
   // Data storage: map from sortable key to roaring bitmap
   std::map<std::string, roaring::Roaring64Map> data_;

--- a/internal/engine/table/scalar_index_result.h
+++ b/internal/engine/table/scalar_index_result.h
@@ -26,9 +26,20 @@ class ScalarIndexResult {
   /**
    * Construct from a Roaring64Map with offset/limit applied in one pass.
    */
-  ScalarIndexResult(const roaring::Roaring64Map& bitmap, int offset, int limit) {
+  ScalarIndexResult(roaring::Roaring64Map bitmap, int offset, int limit) {
     b_not_in_ = false;
+    if (offset < 0 || limit < 0) {
+      return;
+    }
+    // offset = 0 and limit = 0 means no offset and no limit
+    if (offset == 0 && limit == 0) {
+      doc_bitmap_ = std::move(bitmap);
+      return;
+    }
     auto it = bitmap.begin();
+    if ((uint64_t)offset >= bitmap.cardinality()) {
+      return;
+    }
     std::advance(it, offset);
     for (; it != bitmap.end(); ++it) {
       doc_bitmap_.add(*it);
@@ -49,10 +60,18 @@ class ScalarIndexResult {
    */
   ScalarIndexResult(const ScalarIndexResult& other, int offset, int limit) {
     b_not_in_ = other.b_not_in_;
-    if (limit == 0 || offset < 0) {
+    if (offset < 0 || limit < 0) {
+      return;
+    }
+    // offset = 0 and limit = 0 means no offset and no limit
+    if (offset == 0 && limit == 0) {
+      doc_bitmap_ = other.doc_bitmap_;
       return;
     }
     auto it = other.doc_bitmap_.begin();
+    if ((uint64_t)offset >= other.doc_bitmap_.cardinality()) {
+      return;
+    }
     std::advance(it, offset);
     for (; it != other.doc_bitmap_.end(); ++it) {
       doc_bitmap_.add(*it);


### PR DESCRIPTION
…structors

- Change BitmapToResultWithOffsetLimit parameter to pass-by-value with move
- Add negative offset/limit validation to prevent undefined behavior
- Add boundary check: return empty result if offset >= bitmap cardinality
- Optimize path for offset=0 and limit=0 to avoid unnecessary iteration
- Ensure both constructors (from bitmap and from other result) are consistent