### PR TITLE
feat(flat): support RocksDB disk store and optimize FLAT search

### DIFF
--- a/internal/engine/common/gamma_common_data.h
+++ b/internal/engine/common/gamma_common_data.h
@@ -105,6 +105,14 @@ class SearchCondition : public RetrievalContext {
     return true;
   };
 
+  bool IsDeleted(int64_t id) const override {
+#ifndef FAISSLIKE_INDEX
+    return docids_bitmap->Test(id);
+#else
+    return false;
+#endif
+  }
+
   void Init(float min_score, float max_score,
             bitmap::BitmapManager *docids_bitmap, RawVector *raw_vec) {
     this->min_score = min_score;

--- a/internal/engine/index/impl/gamma_index_flat.cc
+++ b/internal/engine/index/impl/gamma_index_flat.cc
@@ -17,13 +17,168 @@
 
 #include "gamma_index_flat.h"
 
+#include <type_traits>
+
 #include "omp.h"
+#include "common/gamma_common_data.h"
 #include "vector/memory_raw_vector.h"
 #include "vector/memory_buffer_raw_vector.h"
 
 using idx_t = faiss::idx_t;
 
 namespace vearch {
+
+namespace {
+
+using HeapForIP = faiss::CMin<float, idx_t>;
+using HeapForL2 = faiss::CMax<float, idx_t>;
+
+// Carries a heap comparator type into a generic lambda so the whole scan flow
+// is instantiated once per metric with the metric branch resolved up front.
+template <class T>
+struct HeapTag {
+  using type = T;
+};
+
+// Per-Search invariants threaded through the scan/score helpers. All fields
+// are constant for the duration of one Search() call; varying inputs (xi,
+// simi/idxi output buffers, the per-call scan range or candidate bitmap)
+// stay as explicit arguments. The metric is not stored here: it is carried as
+// the Heap template parameter so distance selection happens at compile time.
+struct FlatScanCtx {
+  RetrievalContext *retrieval_context;
+  RawVector *raw_vec;
+  int d;
+  int k;
+  int batch_size;
+  const std::string &request_id;
+  int partition_id;
+};
+
+// Score one batch of (already-fetched) vectors against xi and push the
+// surviving ones into the top-k heap. Templated on the heap comparator; the
+// metric follows from the comparator (CMin -> inner product, CMax -> L2), so
+// the distance function is selected at compile time with no per-vector branch.
+template <class Heap>
+inline void ComputeScoreBatch(const FlatScanCtx &ctx, const float *xi,
+                              const std::vector<int64_t> &vid_buf,
+                              ScopeVectors &scope_vecs, float *simi,
+                              idx_t *idxi) {
+  for (size_t j = 0; j < vid_buf.size(); ++j) {
+    const int64_t vid = vid_buf[j];
+    const float *yi = reinterpret_cast<const float *>(scope_vecs.Get(j));
+    if (yi == nullptr) continue;
+
+    float dis;
+    if constexpr (std::is_same_v<Heap, HeapForIP>) {
+      dis = faiss::fvec_inner_product(xi, yi, ctx.d);
+    } else {
+      dis = faiss::fvec_L2sqr(xi, yi, ctx.d);
+    }
+    if (!ctx.retrieval_context->IsSimilarScoreValid(dis)) continue;
+
+    if (Heap::cmp(simi[0], dis)) {
+      faiss::heap_pop<Heap>(ctx.k, simi, idxi);
+      faiss::heap_push<Heap>(ctx.k, simi, idxi, dis, vid);
+    }
+  }
+}
+
+// Scan a contiguous VID range [start_vid, start_vid+nsearch); filter each VID
+// through retrieval_context->IsValid before fetching. Used when no candidate
+// bitmap is available (or filter-first is disabled).
+template <class Heap>
+void FlatScanRange(const FlatScanCtx &ctx, const float *xi, int start_vid,
+                   int nsearch, float *simi, idx_t *idxi) {
+  const int end_vid = start_vid + nsearch;
+  std::vector<int64_t> vid_buf;
+  vid_buf.reserve(ctx.batch_size);
+
+  // Amortize is_killed() across multiple chunks: O(1)/chunk -> O(1)/16 chunks.
+  constexpr int kKillCheckChunks = 16;
+  int chunks_since_kill_check = 0;
+
+  for (int chunk_start = start_vid; chunk_start < end_vid;
+       chunk_start += ctx.batch_size) {
+    if (chunks_since_kill_check++ >= kKillCheckChunks) {
+      chunks_since_kill_check = 0;
+      if (RequestContext::is_killed(ctx.request_id, ctx.partition_id)) {
+        break;
+      }
+    }
+    const int chunk_end = std::min(chunk_start + ctx.batch_size, end_vid);
+
+    vid_buf.clear();
+    for (int vid = chunk_start; vid < chunk_end; ++vid) {
+      if (ctx.retrieval_context->IsValid(vid)) {
+        vid_buf.push_back(vid);
+      }
+    }
+    if (vid_buf.empty()) continue;
+
+    ScopeVectors scope_vecs;
+    int rc = ctx.raw_vec->Gets(vid_buf, scope_vecs);
+    if (rc != 0) {
+      LOG(ERROR) << "Gets failed, rc=" << rc << ", chunk=[" << chunk_start
+                 << "," << chunk_end << ")";
+      return;
+    }
+
+    ComputeScoreBatch<Heap>(ctx, xi, vid_buf, scope_vecs, simi, idxi);
+  }
+}
+
+// Scan only the candidate bitmap (already clipped to this partition's VID
+// range). Candidates already satisfy the scalar predicate, so we only check
+// soft-delete via IsDeleted (skipping the redundant scalar Has() inside
+// IsValid).
+template <class Heap>
+void FlatScanBitmap(const FlatScanCtx &ctx, const float *xi,
+                    const roaring::Roaring64Map &cand, float *simi,
+                    idx_t *idxi) {
+  const uint64_t total = cand.cardinality();
+  std::vector<int64_t> vid_buf;
+  vid_buf.reserve(ctx.batch_size);
+
+  constexpr int kKillCheckChunks = 16;
+  int chunks_since_kill_check = 0;
+
+  // Each call runs on one query (potentially under OMP); the iterator is
+  // value-typed and thread-local, so the shared const bitmap is safe to read
+  // concurrently.
+  auto it = cand.begin();
+  const auto end = cand.end();
+  uint64_t consumed = 0;
+  while (consumed < total) {
+    if (chunks_since_kill_check++ >= kKillCheckChunks) {
+      chunks_since_kill_check = 0;
+      if (RequestContext::is_killed(ctx.request_id, ctx.partition_id)) break;
+    }
+
+    vid_buf.clear();
+    for (int filled = 0; filled < ctx.batch_size && it != end;
+         ++it, ++consumed) {
+      const int64_t vid = static_cast<int64_t>(*it);
+      if (!ctx.retrieval_context->IsDeleted(vid)) {
+        vid_buf.push_back(vid);
+        ++filled;
+      }
+    }
+    if (vid_buf.empty()) continue;
+
+    ScopeVectors scope_vecs;
+    int rc = ctx.raw_vec->Gets(vid_buf, scope_vecs);
+    if (rc != 0) {
+      LOG(ERROR) << "Gets failed (scan_bitmap), rc=" << rc
+                 << ", consumed=" << consumed << "/" << total;
+      return;
+    }
+
+    ComputeScoreBatch<Heap>(ctx, xi, vid_buf, scope_vecs, simi, idxi);
+  }
+}
+
+}  // namespace
 
 REGISTER_INDEX(FLAT, GammaFLATIndex);
 
@@ -71,19 +226,13 @@ GammaFLATIndex::~GammaFLATIndex() {}
 Status GammaFLATIndex::Init(const std::string &model_parameters,
                             int training_threshold) {
   training_threshold_ = 0;
-  auto raw_vec_type = dynamic_cast<MemoryRawVector *>(vector_);
-  if (raw_vec_type == nullptr) {
-    std::string msg = "FLAT can only work in memory only mode";
-    LOG(ERROR) << msg;
-    return Status::ParamError(msg);
-  }
   FLATModelParams flat_param;
   if (model_parameters != "") {
     Status status = flat_param.Parse(model_parameters.c_str());
     if (!status.ok()) return status;
   }
   metric_type_ = flat_param.metric_type;
-  LOG(INFO) << flat_param.ToString();
+  LOG(INFO) << "FLAT Init OK, " << flat_param.ToString();
   return Status::OK();
 }
 
@@ -120,12 +269,99 @@ RetrievalParameters *GammaFLATIndex::Parse(const std::string &parameters) {
   FlatRetrievalParameters *retrieval_params = new FlatRetrievalParameters(
       parallel_on_queries == 0 ? false : true, type);
 
+  int disable_filter_first = 0;
+  if (jp.GetInt("disable_filter_first", disable_filter_first) == 0) {
+    retrieval_params->SetDisableFilterFirst(disable_filter_first != 0);
+  }
+
+  int fetch_batch_size = 0;
+  if (jp.GetInt("fetch_batch_size", fetch_batch_size) == 0) {
+    if (fetch_batch_size < 1 || fetch_batch_size > 1024) {
+      LOG(WARNING) << "invalid fetch_batch_size=" << fetch_batch_size
+                   << ", fallback to default 64";
+    } else {
+      retrieval_params->SetFetchBatchSize(fetch_batch_size);
+    }
+  }
+
   return retrieval_params;
 }
 
 int GammaFLATIndex::Indexing() { return 0; }
 
 bool GammaFLATIndex::Add(int n, const uint8_t *vec) { return true; }
+
+bool GammaFLATIndex::AcquireBufferScanRange(MemoryBufferRawVector *memory_buf,
+                                            int total_vectors,
+                                            int &start_offset_vid,
+                                            int &num_vectors,
+                                            int &start_segment_id,
+                                            int &end_segment_id) {
+  start_segment_id = memory_buf->GetStartSegmentId();
+  end_segment_id = memory_buf->GetNsegments();
+  start_offset_vid = memory_buf->GetIndexedCount();
+  if (start_offset_vid >= total_vectors) {
+    return false;
+  }
+  if (start_offset_vid < 0) {
+    start_offset_vid = 0;
+  }
+  for (int i = start_segment_id; i < end_segment_id; i++) {
+    memory_buf->IncrementSegmentRef(i);
+  }
+  num_vectors = total_vectors - start_offset_vid;
+  return true;
+}
+
+void GammaFLATIndex::DecrementSegmentRefs(MemoryBufferRawVector *memory_buf,
+                                          int start_segment_id,
+                                          int end_segment_id) {
+  if (memory_buf == nullptr) return;
+  for (int i = start_segment_id; i < end_segment_id; i++) {
+    memory_buf->DecrementSegmentRef(i);
+  }
+}
+
+void GammaFLATIndex::PlanBitmapScan(
+    RetrievalContext *retrieval_context,
+    FlatRetrievalParameters *retrieval_params, int n, int start_offset_vid,
+    int num_vectors, roaring::Roaring64Map &candidates,
+    bool &scan_bitmap) {
+  scan_bitmap = false;
+
+  SearchCondition *condition =
+      dynamic_cast<SearchCondition *>(retrieval_context);
+  ScalarIndexResults *scalar_results =
+      condition ? condition->ScalarIndexResult() : nullptr;
+  const bool eligible = (scalar_results != nullptr) &&
+                        (!retrieval_params->DisableFilterFirst()) &&
+                        (scalar_results->Cardinality() > 0);
+  if (!eligible) return;
+
+  const roaring::Roaring64Map *src = scalar_results->GetCandidateBitmap();
+  if (src == nullptr) return;
+
+  const uint64_t lower = static_cast<uint64_t>(start_offset_vid);
+  const uint64_t upper =
+      static_cast<uint64_t>(start_offset_vid) + (uint64_t)num_vectors;
+  roaring::Roaring64Map range_mask;
+  range_mask.addRange(lower, upper);
+  candidates = *src;
+  candidates &= range_mask;
+
+  const int64_t cand_card = candidates.cardinality();
+  if (cand_card == 0) return;
+
+  // When n == 1 and the candidate set is large, skip the
+  // bitmap scan and let the dispatch take the "parallelize over vectors" path
+  // so single-query searches (especially on Memory FLAT) regain inner-loop CPU
+  // parallelism. The threshold matches a single fetch batch: below it, OMP
+  // startup cost outweighs the per-vid IsValid work that the bitmap scan skips.
+  constexpr int64_t kScanBitmapSingleQueryMax = 1024;
+  const bool single_query_bailout =
+      (n == 1) && (cand_card > kScanBitmapSingleQueryMax);
+  scan_bitmap = !single_query_bailout;
+}
 
 int GammaFLATIndex::Search(RetrievalContext *retrieval_context, int n,
                            const uint8_t *x, int k, float *distances,
@@ -156,21 +392,11 @@ int GammaFLATIndex::Search(RetrievalContext *retrieval_context, int n,
   int start_offset_vid = 0;
   auto memory_buf = dynamic_cast<MemoryBufferRawVector *>(raw_vec);
   int start_segment_id = 0, end_segment_id = 0;
-  if (memory_buf != nullptr) {
-    start_segment_id = memory_buf->GetStartSegmentId();
-    end_segment_id = memory_buf->GetNsegments();
-    start_offset_vid = memory_buf->GetIndexedCount();
-    if (start_offset_vid >= num_vectors) {
-      return 0;
-    }
-    if (start_offset_vid < 0) {
-      start_offset_vid = 0;
-    }
-    for (int i = start_segment_id; i < end_segment_id; i++) {
-      memory_buf->IncrementSegmentRef(i);
-    }
+  if (memory_buf != nullptr &&
+      !AcquireBufferScanRange(memory_buf, num_vectors, start_offset_vid,
+                              num_vectors, start_segment_id, end_segment_id)) {
+    return 0;
   }
-  num_vectors -= start_offset_vid;
 
   int d = vector_->MetaInfo()->Dimension();
 
@@ -181,179 +407,121 @@ int GammaFLATIndex::Search(RetrievalContext *retrieval_context, int n,
   } else {
     metric_type = faiss::METRIC_L2;
   }
-  using HeapForIP = faiss::CMin<float, idx_t>;
-  using HeapForL2 = faiss::CMax<float, idx_t>;
 
   if (RequestContext::is_killed()) {
-    if (memory_buf != nullptr) {
-      for (int i = start_segment_id; i < end_segment_id; i++) {
-        memory_buf->DecrementSegmentRef(i);
-      }
-    }
+    DecrementSegmentRefs(memory_buf, start_segment_id, end_segment_id);
     return -2;
   }
   std::string request_id = RequestContext::get_current_request()->RequestId();
   int partition_id = RequestContext::get_partition_id();
 
+  roaring::Roaring64Map candidates;
+  bool scan_bitmap = false;
+  PlanBitmapScan(retrieval_context, retrieval_params, n, start_offset_vid,
+                 num_vectors, candidates, scan_bitmap);
+
   {
     // we must obtain the num of threads in *THE* parallel area.
     int num_threads = omp_get_max_threads();
+    const FlatScanCtx ctx{
+        retrieval_context, raw_vec, d, k, retrieval_params->FetchBatchSize(),
+        request_id,        partition_id};
 
-    /*****************************************************
-     * Depending on parallel_mode, there are two possible ways
-     * to organize the search. Here we define local functions
-     * that are in common between the two
-     ******************************************************/
-
-    auto init_result = [&](int k, float *simi, idx_t *idxi) {
-      if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-        faiss::heap_heapify<HeapForIP>(k, simi, idxi);
-      } else {
-        faiss::heap_heapify<HeapForL2>(k, simi, idxi);
-      }
-    };
-
-    auto reorder_result = [&](int k, float *simi, idx_t *idxi) {
-      if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-        faiss::heap_reorder<HeapForIP>(k, simi, idxi);
-      } else {
-        faiss::heap_reorder<HeapForL2>(k, simi, idxi);
-      }
-    };
-
-    auto search_impl = [&](const float *xi, int start_vid, int nsearch,
-                           float *simi, idx_t *idxi, int k) {
-      if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-        for (int vid = start_vid; vid < start_vid + nsearch; ++vid) {
-          if (RequestContext::is_killed(request_id, partition_id)) {
-            break;
-          }
-
-          if (!retrieval_context->IsValid(vid)) {
-            continue;
-          }
-
-          ScopeVector scope_vec;
-          raw_vec->GetVector(vid, scope_vec);
-          const float *yi = reinterpret_cast<const float *>(scope_vec.Get());
-          float dis = -2;
-          if (yi != nullptr) {
-            dis = faiss::fvec_inner_product(xi, yi, d);
-          }
-
-          if (!retrieval_context->IsSimilarScoreValid(dis)) {
-            continue;
-          }
-
-          if (HeapForIP::cmp(simi[0], dis)) {
-            faiss::heap_pop<HeapForIP>(k, simi, idxi);
-            faiss::heap_push<HeapForIP>(k, simi, idxi, dis, vid);
-          }
-        }
-      } else {
-        for (int vid = start_vid; vid < start_vid + nsearch; ++vid) {
-          if (RequestContext::is_killed(request_id, partition_id)) {
-            break;
-          }
-
-          if (!retrieval_context->IsValid(vid)) {
-            continue;
-          }
-
-          ScopeVector scope_vec;
-          raw_vec->GetVector(vid, scope_vec);
-          const float *yi = reinterpret_cast<const float *>(scope_vec.Get());
-          float dis = -2;
-          if (yi != nullptr) {
-            dis = faiss::fvec_L2sqr(xi, yi, d);
-          }
-
-          if (!retrieval_context->IsSimilarScoreValid(dis)) {
-            continue;
-          }
-
-          if (HeapForL2::cmp(simi[0], dis)) {
-            faiss::heap_pop<HeapForL2>(k, simi, idxi);
-            faiss::heap_push<HeapForL2>(k, simi, idxi, dis, vid);
-          }
-        }
-      }
-    };
     bool parallel_on_queries =
         (retrieval_params->ParallelOnQueries() == true) && (n > 1);
 
     int threads_num = n < omp_get_max_threads() ? n : omp_get_max_threads();
 
-    if (parallel_on_queries) {  // parallelize over queries
-#pragma omp parallel for schedule(dynamic) num_threads(threads_num)
-      for (int i = 0; i < n; i++) {
-        if (!RequestContext::is_killed(request_id, partition_id)) {
-          const float *xi = xq + i * d;
+    // Two orthogonal axes decide the scan:
+    //   - scan source: scan_bitmap -> candidate bitmap, else full VID range.
+    //   - parallel axis: over queries (one query per thread) vs over vectors
+    //     (one VID sub-range per thread, merged under a critical section).
+    // They are not fully independent: a candidate bitmap cannot be split into
+    // contiguous VID sub-ranges, so scan_bitmap is pinned to the over-queries
+    // axis. Over-vectors is therefore the only path that yields parallelism
+    // when n == 1 -- which is exactly why PlanBitmapScan clears
+    // scan_bitmap for large single queries (so they land here, not on a
+    // single-threaded over-queries loop).
+    const bool over_queries = scan_bitmap || parallel_on_queries;
 
+    // Instantiated once per metric (Heap = CMin for IP, CMax for L2) so every
+    // heap op and distance call below resolves at compile time.
+    auto run_search = [&](auto heap_tag) {
+      using Heap = typename decltype(heap_tag)::type;
+      if (over_queries) {  // parallelize over queries
+#pragma omp parallel for schedule(dynamic) num_threads(threads_num)
+        for (int i = 0; i < n; i++) {
+          if (RequestContext::is_killed(request_id, partition_id)) continue;
+          const float *xi = xq + i * d;
           float *simi = distances + i * k;
           idx_t *idxi = (idx_t *)labels + i * k;
 
-          init_result(k, simi, idxi);
+          faiss::heap_heapify<Heap>(k, simi, idxi);
 
-          search_impl(xi, start_offset_vid, num_vectors, simi, idxi, k);
+          if (scan_bitmap) {
+            FlatScanBitmap<Heap>(ctx, xi, candidates, simi, idxi);
+          } else {
+            FlatScanRange<Heap>(ctx, xi, start_offset_vid, num_vectors, simi,
+                                idxi);
+          }
 
-          reorder_result(k, simi, idxi);
+          faiss::heap_reorder<Heap>(k, simi, idxi);
         }
-      }
-    } else {  // parallelize over vectors
+      } else {  // parallelize over vectors
 
-      size_t num_vectors_per_thread = num_vectors / num_threads;
+        size_t num_vectors_per_thread = num_vectors / num_threads;
 
-      for (int i = 0; i < n; i++) {
-        const float *xi = xq + i * d;
+        for (int i = 0; i < n; i++) {
+          const float *xi = xq + i * d;
 
-        // merge thread-local results
-        float *simi = distances + i * k;
-        idx_t *idxi = (idx_t *)labels + i * k;
-        init_result(k, simi, idxi);
+          // merge thread-local results
+          float *simi = distances + i * k;
+          idx_t *idxi = (idx_t *)labels + i * k;
+          faiss::heap_heapify<Heap>(k, simi, idxi);
 
 #pragma omp parallel for schedule(dynamic)
-        for (int ik = 0; ik < num_threads; ik++) {
-          if (!RequestContext::is_killed(request_id, partition_id)) {
-            std::vector<idx_t> local_idx(k);
-            std::vector<float> local_dis(k);
-            init_result(k, local_dis.data(), local_idx.data());
+          for (int ik = 0; ik < num_threads; ik++) {
+            if (!RequestContext::is_killed(request_id, partition_id)) {
+              std::vector<idx_t> local_idx(k);
+              std::vector<float> local_dis(k);
+              faiss::heap_heapify<Heap>(k, local_dis.data(), local_idx.data());
 
-            size_t ny = num_vectors_per_thread;
+              size_t ny = num_vectors_per_thread;
 
-            if (ik == num_threads - 1) {
-              ny += num_vectors % num_threads;  // the rest
-            }
+              if (ik == num_threads - 1) {
+                ny += num_vectors % num_threads;  // the rest
+              }
 
-            int offset = start_offset_vid + ik * num_vectors_per_thread;
+              int offset = start_offset_vid + ik * num_vectors_per_thread;
 
-            search_impl(xi, offset, ny, local_dis.data(), local_idx.data(), k);
+              FlatScanRange<Heap>(ctx, xi, offset, ny, local_dis.data(),
+                                  local_idx.data());
 
 #pragma omp critical
-            {
-              if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-                faiss::heap_addn<HeapForIP>(k, simi, idxi, local_dis.data(),
-                                          local_idx.data(), k);
-              } else {
-                faiss::heap_addn<HeapForL2>(k, simi, idxi, local_dis.data(),
-                                          local_idx.data(), k);
+              {
+                faiss::heap_addn<Heap>(k, simi, idxi, local_dis.data(),
+                                       local_idx.data(), k);
               }
             }
           }
-        }
 
-        if (RequestContext::is_killed(request_id, partition_id)) {
-          break;
+          if (RequestContext::is_killed(request_id, partition_id)) {
+            break;
+          }
+          faiss::heap_reorder<Heap>(k, simi, idxi);
         }
-        reorder_result(k, simi, idxi);
       }
+    };
+
+    if (metric_type == faiss::METRIC_INNER_PRODUCT) {
+      run_search(HeapTag<HeapForIP>{});
+    } else {
+      run_search(HeapTag<HeapForL2>{});
     }
   }  // parallel
 
   if (memory_buf != nullptr) {
-    for (int i = start_segment_id; i < end_segment_id; i++) {
-      memory_buf->DecrementSegmentRef(i);
-    }
+    DecrementSegmentRefs(memory_buf, start_segment_id, end_segment_id);
   }
 
   if (RequestContext::is_killed(request_id, partition_id)) {

--- a/internal/engine/index/impl/gamma_index_flat.h
+++ b/internal/engine/index/impl/gamma_index_flat.h
@@ -27,12 +27,16 @@
 #include "faiss/utils/distances.h"
 #include "faiss/utils/hamming.h"
 #include "faiss/utils/utils.h"
+#include <roaring/roaring64map.hh>
+
 #include "index/index_model.h"
 #include "util/bitmap.h"
 #include "util/log.h"
 #include "util/utils.h"
 
 namespace vearch {
+
+class MemoryBufferRawVector;
 
 class FlatRetrievalParameters : public RetrievalParameters {
  public:
@@ -58,9 +62,17 @@ class FlatRetrievalParameters : public RetrievalParameters {
     parallel_on_queries_ = parallel_on_queries;
   }
 
+  bool DisableFilterFirst() const { return disable_filter_first_; }
+  void SetDisableFilterFirst(bool v) { disable_filter_first_ = v; }
+
+  int FetchBatchSize() const { return fetch_batch_size_; }
+  void SetFetchBatchSize(int v) { fetch_batch_size_ = v; }
+
  private:
   // parallelize over queries or vectors
   bool parallel_on_queries_;
+  bool disable_filter_first_ = false;
+  int fetch_batch_size_ = 64;
 };
 
 class GammaFLATIndex : public IndexModel {
@@ -95,6 +107,31 @@ class GammaFLATIndex : public IndexModel {
   DistanceComputeType metric_type_;
 
   int rerank_ = 0;
+
+ private:
+  // Acquire per-segment refs for the given MemoryBufferRawVector and compute
+  // the partition-local VID range to scan. The caller guarantees memory_buf is
+  // non-null (non-buffer backends skip this call and scan the full range).
+  // Returns true when there is a range to scan; returns false when the buffer
+  // has no unindexed tail (callers should short-circuit to 0 results).
+  bool AcquireBufferScanRange(MemoryBufferRawVector *memory_buf,
+                              int total_vectors, int &start_offset_vid,
+                              int &num_vectors, int &start_segment_id,
+                              int &end_segment_id);
+
+  // Decrement segment refs acquired by AcquireBufferScanRange. Safe to call
+  // with memory_buf == nullptr (no-op).
+  void DecrementSegmentRefs(MemoryBufferRawVector *memory_buf,
+                            int start_segment_id, int end_segment_id);
+
+  // Decide whether to scan the candidate bitmap and clip it to this
+  // partition's VID range. On return, `scan_bitmap` reflects the final gating
+  // decision (including the single-query large-candidate fallback).
+  void PlanBitmapScan(RetrievalContext *retrieval_context,
+                      FlatRetrievalParameters *retrieval_params, int n,
+                      int start_offset_vid, int num_vectors,
+                      roaring::Roaring64Map &candidates,
+                      bool &scan_bitmap);
 };
 
 }  // namespace vearch

--- a/internal/engine/index/index_model.h
+++ b/internal/engine/index/index_model.h
@@ -9,6 +9,7 @@
 
 #include <tbb/concurrent_queue.h>
 
+#include <memory>
 #include <vector>
 
 #include "reflector.h"
@@ -99,6 +100,12 @@ class RetrievalContext {
 
   // ID valid filter
   virtual bool IsValid(int64_t id) const = 0;
+
+  // Soft-delete check only. Filter-first paths whose candidates already
+  // satisfy the scalar predicate use this to avoid a redundant scalar
+  // membership query inside IsValid. Default false so contexts without a
+  // delete bitmap (e.g. faiss-like indexes) keep working unchanged.
+  virtual bool IsDeleted(int64_t /*id*/) const { return false; }
 
   // Score filter
   virtual bool IsSimilarScoreValid(float score) const = 0;
@@ -324,7 +331,7 @@ class IndexModel {
 
   std::string &Desc() { return desc_; }
 
-   bool SupportIncrement() const { return support_increment_; }
+  bool SupportIncrement() const { return support_increment_; }
 
   VectorReader *vector_;
   tbb::concurrent_bounded_queue<int64_t> updated_vids_;

--- a/internal/engine/table/inverted_index.cc
+++ b/internal/engine/table/inverted_index.cc
@@ -204,7 +204,7 @@ ScalarIndexResult InvertedIndex::NotIn(const std::vector<std::string>& values, i
   ScalarIndexResult matched = In(values, 0, 0);
 
   result.AddRange(0, total_size);
-  result.IntersectionWithNotIn(matched);
+  result.Difference(matched);
 
   if (offset > 0 || limit > 0) {
     ScalarIndexResult offset_limited(result, offset, limit);

--- a/internal/engine/table/scalar_index_result.h
+++ b/internal/engine/table/scalar_index_result.h
@@ -12,22 +12,24 @@
 #include <string>
 #include <vector>
 
-#include "util/log.h"
-
 namespace vearch {
 
+// Result of evaluating a single scalar filter condition (or the merged
+// result of several conditions combined by AND/OR/NOT IN via the
+// Intersection/Union/Difference ops below).
+//
+// Internally a Roaring64Map over docids.
 class ScalarIndexResult {
  public:
  ScalarIndexResult() { Clear(); }
 
  ScalarIndexResult(ScalarIndexResult&& other) noexcept
-      : b_not_in_(other.b_not_in_), doc_bitmap_(std::move(other.doc_bitmap_)) {}
+      : doc_bitmap_(std::move(other.doc_bitmap_)) {}
 
   /**
    * Construct from a Roaring64Map with offset/limit applied in one pass.
    */
   ScalarIndexResult(roaring::Roaring64Map bitmap, int offset, int limit) {
-    b_not_in_ = false;
     if (offset < 0 || limit < 0) {
       return;
     }
@@ -53,13 +55,12 @@ class ScalarIndexResult {
    * Construct from a Roaring64Map (copy).
    */
   explicit ScalarIndexResult(const roaring::Roaring64Map& bitmap)
-      : b_not_in_(false), doc_bitmap_(bitmap) {}
+      : doc_bitmap_(bitmap) {}
 
   /**
    * Copy with offset/limit applied.
    */
   ScalarIndexResult(const ScalarIndexResult& other, int offset, int limit) {
-    b_not_in_ = other.b_not_in_;
     if (offset < 0 || limit < 0) {
       return;
     }
@@ -83,7 +84,6 @@ class ScalarIndexResult {
 
   ScalarIndexResult& operator=(ScalarIndexResult&& other) noexcept {
     if (this != &other) {
-      b_not_in_ = other.b_not_in_;
       doc_bitmap_ = std::move(other.doc_bitmap_);
     }
     return *this;
@@ -95,32 +95,18 @@ class ScalarIndexResult {
     doc_bitmap_ &= other.doc_bitmap_;
   }
 
-  void IntersectionWithNotIn(const ScalarIndexResult& other) {
-    if (b_not_in_) {
-      doc_bitmap_ &= other.doc_bitmap_;
-    } else {
-      doc_bitmap_ -= other.doc_bitmap_;
-    }
+  // Set difference: remove docids present in `other`. Used to implement
+  // NOT IN as "[0, total) minus matched".
+  void Difference(const ScalarIndexResult& other) {
+    doc_bitmap_ -= other.doc_bitmap_;
   }
 
   void Union(const ScalarIndexResult& other) {
     doc_bitmap_ |= other.doc_bitmap_;
   }
 
-  void UnionWithNotIn(const ScalarIndexResult& other) {
-    if (b_not_in_) {
-      doc_bitmap_ |= other.doc_bitmap_;
-    } else {
-      doc_bitmap_ -= other.doc_bitmap_;
-    }
-  }
-
   bool Has(int64_t doc) const {
-    if (b_not_in_) {
-      return !doc_bitmap_.contains(static_cast<uint64_t>(doc));
-    } else {
-      return doc_bitmap_.contains(static_cast<uint64_t>(doc));
-    }
+    return doc_bitmap_.contains(static_cast<uint64_t>(doc));
   }
 
   int64_t Cardinality() const { return doc_bitmap_.cardinality(); }
@@ -129,11 +115,6 @@ class ScalarIndexResult {
 
   std::vector<uint64_t> GetDocIDs(size_t topn) const {
     std::vector<uint64_t> doc_ids;
-    if (b_not_in_) {
-      LOG(WARNING) << "NOT IN operation is not supported in GetDocIDs";
-      return doc_ids;
-    }
-
     doc_ids.reserve(
         doc_bitmap_.cardinality() > topn ? topn : doc_bitmap_.cardinality());
 
@@ -144,10 +125,7 @@ class ScalarIndexResult {
     return doc_ids;
   }
 
-  void Clear() {
-    b_not_in_ = false;
-    doc_bitmap_.clear();
-  }
+  void Clear() { doc_bitmap_.clear(); }
 
   void Add(int64_t doc) { doc_bitmap_.add(static_cast<uint64_t>(doc)); }
   void AddRange(int64_t mindoc, int64_t maxdoc) {
@@ -155,22 +133,45 @@ class ScalarIndexResult {
                          static_cast<uint64_t>(maxdoc));
   }
 
-  void SetNotIn(bool b_not_in) { b_not_in_ = b_not_in; }
-
-  bool NotIn() { return b_not_in_; }
-
  private:
-  bool b_not_in_;
   roaring::Roaring64Map doc_bitmap_;
 };
 
+// Container for the scalar-filter outcome of a single search request.
+//
+// Despite the plural name and the `std::vector<ScalarIndexResult>` member,
+// in the current code path this holds **at most one** ScalarIndexResult:
+// ScalarIndexManager::Search merges every per-filter result (via
+// Intersection/Union according to the request's FilterOperator) into a
+// single final ScalarIndexResult and pushes that one result via Add().
+// Downstream consumers (filter-first vector search, GetDocIDs, etc.) only
+// ever read `all_results_[0]`.
+//
+// The vector-of-results shape is a historical artifact from when each
+// field's result was kept separate and intersected lazily during recall;
+// kept for ABI/source compatibility with existing callers.
+//
+// Invariants assumed by callers:
+//   - Size() is 0 or 1.
+//   - GetCandidateBitmap()/Cardinality()/GetDocIDs() only consult
+//     all_results_[0].
+//
+// TODO(refactor): Collapse this class. Since `all_results_` is provably
+// 0-or-1, the wrapper buys nothing over a single
+// `std::optional<ScalarIndexResult>` (or just a ScalarIndexResult with an
+// "empty" state) -- and the misleading plural name keeps tempting readers
+// to assume per-field results live here.
 class ScalarIndexResults {
  public:
   ScalarIndexResults() { Clear(); }
 
   ~ScalarIndexResults() { Clear(); }
 
-  // Take full advantage of multi-core while recalling
+  // Per-doc predicate check used by recall paths.
+  // Given the Size() <= 1 invariant above, this is effectively
+  // `all_results_[0].Has(doc)` (or `false` when empty); the AND-loop is
+  // retained for the historical multi-result case but degenerates to a
+  // single call in current usage.
   bool Has(int64_t doc) const {
     if (all_results_.size() == 0) {
       return false;
@@ -197,6 +198,24 @@ class ScalarIndexResults {
       return doc_ids;
     }
     return all_results_[0].GetDocIDs(topn);
+  }
+
+  // Direct bitmap accessor for filter-first paths that want to avoid
+  // materializing the candidate set into a std::vector. Returns nullptr when
+  // there is no result.
+  // Invariant: only all_results_[0] is consulted (all_results_ holds at most
+  // one already-intersected result).
+  const roaring::Roaring64Map *GetCandidateBitmap() const {
+    if (all_results_.size() == 0) return nullptr;
+    return &all_results_[0].GetDocBitmap();
+  }
+
+  // Candidate cardinality (Roaring64Map::cardinality, O(#containers)), used by
+  // filter-first gating to avoid materializing the candidate vector just to
+  // read its size.
+  int64_t Cardinality() const {
+    if (all_results_.size() == 0) return 0;
+    return all_results_[0].Cardinality();
   }
 
  private:

--- a/test/test_module_filter.py
+++ b/test/test_module_filter.py
@@ -1082,3 +1082,272 @@ def test_module_filter_bitmap_index_thread_safety():
     assert delete_count[0] == total
 
     logger.info("Bitmap index thread safety test passed")
+
+
+# ----------------------------------------------------------------------
+# M7 filter-first (M3) + fetch_batch_size (M4) tests
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def ff_space_cleanup():
+    """Drop the filter-first test space/db on teardown.
+
+    Without this, an assertion failure leaves the trailing destroy() unreached,
+    leaking the space so the next parametrized variant's create_space fails and
+    cascades unrelated failures.
+    """
+    yield
+    destroy(router_url, db_name, space_name)
+
+
+def _ff_create_space(store_type: str, embedding_size: int):
+    properties = {
+        "fields": [
+            {
+                "name": "field_int",
+                "type": "integer",
+                "index": {"name": "field_int", "type": "SCALAR"},
+            },
+            {
+                "name": "field_string",
+                "type": "string",
+                "index": {"name": "field_string", "type": "SCALAR"},
+            },
+            {
+                "name": "field_vector",
+                "type": "vector",
+                "dimension": embedding_size,
+                "store_type": store_type,
+                "index": {
+                    "name": "gamma",
+                    "type": "FLAT",
+                    "params": {"metric_type": "L2"},
+                },
+            },
+        ]
+    }
+    create(router_url, properties)
+
+
+def _ff_add_docs(n: int, embedding_size: int, seed: int = 42):
+    rng = np.random.RandomState(seed)
+    xb = rng.random((n, embedding_size)).astype("float32")
+    url = router_url + "/document/upsert?timeout=2000000"
+    batch_size = 100
+    total_batch = n // batch_size
+    for b in range(total_batch):
+        documents = []
+        for j in range(batch_size):
+            idx = b * batch_size + j
+            documents.append(
+                {
+                    "_id": str(idx),
+                    "field_int": idx,
+                    "field_string": str(idx),
+                    "field_vector": xb[idx].tolist(),
+                }
+            )
+        rs = requests.post(
+            url,
+            auth=(username, password),
+            json={
+                "db_name": db_name,
+                "space_name": space_name,
+                "documents": documents,
+            },
+        )
+        assert rs.json()["code"] == 0, rs.json()
+    waiting_index_finish(n)
+    return xb
+
+
+def _ff_search(xq_vec, retrieval_params=None, filters=None, limit=10):
+    url = router_url + "/document/search?timeout=2000000"
+    data = {
+        "db_name": db_name,
+        "space_name": space_name,
+        "vector_value": False,
+        "fields": ["field_int"],
+        "limit": limit,
+        "vectors": [{"field": "field_vector", "feature": xq_vec.tolist()}],
+    }
+    if retrieval_params:
+        data["index_params"] = retrieval_params
+    if filters is not None:
+        data["filters"] = filters
+    rs = requests.post(url, auth=(username, password), json=data)
+    body = rs.json()
+    assert body["code"] == 0, body
+    docs = body["data"]["documents"]
+    return docs[0] if docs else []
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_low_cardinality(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": 0},
+            {"field": "field_int", "operator": "<", "value": 10},
+        ],
+    }
+    res_ff = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=0),
+        filters=filters, limit=10,
+    )
+    res_m2 = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=1),
+        filters=filters, limit=10,
+    )
+    assert_bit_wise_equal(res_ff, res_m2)
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_zero_hit(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": 10 * n},
+        ],
+    }
+    res = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=0),
+        filters=filters, limit=10,
+    )
+    assert len(res) == 0
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_disable(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": 0},
+            {"field": "field_int", "operator": "<", "value": 100},
+        ],
+    }
+    res_default = _ff_search(xq, filters=filters, limit=10)
+    res_off = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=1),
+        filters=filters, limit=10,
+    )
+    assert_bit_wise_equal(res_default, res_off)
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_full_hit(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": -1},
+        ],
+    }
+    res_ff = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=0),
+        filters=filters, limit=10,
+    )
+    res_m2 = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=1),
+        filters=filters, limit=10,
+    )
+    assert_bit_wise_equal(res_ff, res_m2)
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_min_chunk(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": "=", "value": 0},
+        ],
+    }
+    res = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=0),
+        filters=filters, limit=10,
+    )
+    assert len(res) == 1
+    assert res[0]["_id"] == "0"
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+def test_filter_first_multi_filter_size2(store_type: str, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": 0},
+            {"field": "field_int", "operator": "<", "value": 200},
+            {
+                "field": "field_string",
+                "operator": "IN",
+                "value": [str(i) for i in range(0, 100)],
+            },
+        ],
+    }
+    res_ff = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=0),
+        filters=filters, limit=10,
+    )
+    res_m2 = _ff_search(
+        xq, retrieval_params=build_retrieval_params(disable_filter_first=1),
+        filters=filters, limit=10,
+    )
+    # Candidates are field_int in [0,200) AND field_string in [0,100) -> ids 0..99,
+    # i.e. exactly 100 candidates. That is well above limit=10, so the top-k must be
+    # filled and the multi-condition filter-first candidate bitmap path is exercised
+    # rather than short-circuited on a zero-cardinality set.
+    assert len(res_ff) == 10
+    assert_bit_wise_equal(res_ff, res_m2)
+
+
+@pytest.mark.parametrize("store_type", ["MemoryOnly", "RocksDB"])
+@pytest.mark.parametrize("batch_size", [0, -1, 1, 1024, 99999])
+def test_fetch_batch_size_clamp(store_type: str, batch_size: int, ff_space_cleanup):
+    embedding_size = 8
+    n = 1000
+    _ff_create_space(store_type, embedding_size)
+    xb = _ff_add_docs(n, embedding_size)
+    xq = xb[0]
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "field_int", "operator": ">=", "value": 0},
+            {"field": "field_int", "operator": "<", "value": 100},
+        ],
+    }
+    res_clamped = _ff_search(
+        xq, retrieval_params=build_retrieval_params(fetch_batch_size=batch_size),
+        filters=filters, limit=10,
+    )
+    res_default = _ff_search(xq, filters=filters, limit=10)
+    assert_bit_wise_equal(res_clamped, res_default)

--- a/test/test_module_space.py
+++ b/test/test_module_space.py
@@ -1292,3 +1292,39 @@ class TestSpaceIndexes:
 
     def test_destroy_db(self):
         drop_db(router_url, db_name)
+
+
+# ----------------------------------------------------------------------
+# M7 (M6 下放): FLAT space guard — RocksDB + MemoryOnly schema creation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("store_type", ["RocksDB", "MemoryOnly"])
+def test_flat_space_schema_guard(store_type: str):
+    embedding_size = 64
+    space_cfg = {
+        "name": space_name,
+        "partition_num": 1,
+        "replica_num": 1,
+        "fields": [
+            {"name": "field_int", "type": "integer"},
+            {
+                "name": "field_vector",
+                "type": "vector",
+                "dimension": embedding_size,
+                "store_type": store_type,
+                "index": {
+                    "name": "gamma",
+                    "type": "FLAT",
+                    "params": {"metric_type": "L2"},
+                },
+            },
+        ],
+    }
+    create_db(router_url, db_name)
+    resp = create_space(router_url, db_name, space_cfg)
+    body = resp.json()
+    assert body["code"] == 0, body
+    got = get_space(router_url, db_name, space_name)
+    assert got.json()["code"] == 0
+    destroy(router_url, db_name, space_name)

--- a/test/test_vearch.py
+++ b/test/test_vearch.py
@@ -555,13 +555,14 @@ class VearchCase:
         self.test_deleteDB()
 
 
-# for FLAT HNSW IVFFLAT, now only support one store_type, no need to set
+# for HNSW IVFFLAT, now only support one store_type, no need to set
 
 
 @pytest.mark.parametrize(
     ["training_threshold", "index_type", "store_type"],
     [
-        [1, "FLAT", ""],
+        [1, "FLAT", "MemoryOnly"],
+        [1, "FLAT", "RocksDB"],
         [990, "IVFPQ", "MemoryOnly"],
         [990, "IVFPQ", "RocksDB"],
         [1, "HNSW", ""],
@@ -592,7 +593,8 @@ def test_vearch_basic_usage_with_realtime(training_threshold: int, index_type: s
 @pytest.mark.parametrize(
     ["training_threshold", "index_type", "store_type"],
     [
-        [1, "FLAT", ""],
+        [1, "FLAT", "MemoryOnly"],
+        [1, "FLAT", "RocksDB"],
         [990, "IVFPQ", "MemoryOnly"],
         [990, "IVFPQ", "RocksDB"],
         [1, "HNSW", ""],
@@ -611,7 +613,6 @@ def test_vearch_usage_operator_metadata(training_threshold: int, index_type: str
 @pytest.mark.parametrize(
     ["training_threshold", "index_type", "store_type"],
     [
-        [1, "FLAT", "RocksDB"],
         [1, "FLAT", "NOTSUPPORTTYPE"],
         [1, "HNSW", "RocksDB"],
         [990, "IVFFLAT", "MemoryOnly"],

--- a/test/test_vector_index_flat.py
+++ b/test/test_vector_index_flat.py
@@ -162,6 +162,7 @@ gt = sift10k.get_groundtruth()
     ["store_type"],
     [
         ["MemoryOnly"],
+        ["RocksDB"],
     ],
 )
 def test_vearch_index_flat_l2(store_type: str):
@@ -178,6 +179,7 @@ glove_gt = glove25.get_groundtruth()[:100]
     ["store_type"],
     [
         ["MemoryOnly"],
+        ["RocksDB"],
     ],
 )
 def test_vearch_index_flat_ip(store_type: str):

--- a/test/utils/vearch_utils.py
+++ b/test/utils/vearch_utils.py
@@ -36,7 +36,32 @@ SCALAR_INDEX_TYPE_STRING = "SCALAR"
 INVERTED_INDEX_TYPE_STRING = "INVERTED"
 BITMAP_INDEX_TYPE_STRING = "BITMAP"
 
+SCORE_EPS = 1e-5
+
 __description__ = """ test utils for vearch """
+
+
+def build_retrieval_params(disable_filter_first=None, fetch_batch_size=None, **extra):
+    params = {}
+    if disable_filter_first is not None:
+        params["disable_filter_first"] = int(disable_filter_first)
+    if fetch_batch_size is not None:
+        params["fetch_batch_size"] = int(fetch_batch_size)
+    params.update(extra)
+    return params
+
+
+def assert_bit_wise_equal(res_a, res_b):
+    assert len(res_a) == len(res_b), \
+        f"length mismatch: {len(res_a)} != {len(res_b)}"
+    sa = sorted(res_a, key=lambda x: x["_id"])
+    sb = sorted(res_b, key=lambda x: x["_id"])
+    for a, b in zip(sa, sb):
+        assert a["_id"] == b["_id"], \
+            f"id mismatch: {a['_id']} != {b['_id']}"
+        diff = abs(a["_score"] - b["_score"])
+        assert diff < SCORE_EPS, \
+            f"score diff {diff} >= eps {SCORE_EPS} on id={a['_id']}"
 
 
 def process_add_data(items):


### PR DESCRIPTION
FLAT index now supports any RawVector backend (Memory / MemoryBuffer / RocksDB), removing the prior Memory-only restriction in Init.

Search-path optimizations:
- Chunked batched Gets() in the per-vid scan, replacing per-vid Get calls; reduces RocksDB round-trips on disk-backed FLAT.
- Configurable fetch_batch_size (1..1024, default 64) and disable_filter_first switch via retrieval params.
- Filter-first gating: when a scalar candidate bitmap is available, clip it to the partition VID range via Roaring SIMD AND, then iterate the bitmap directly instead of scanning all vectors. Falls back to the vector-segment-parallel path when n==1 and the candidate cardinality exceeds 1024 so single-query Memory FLAT keeps inner-loop CPU parallelism.
- Amortized RequestContext::is_killed() check (every 16 chunks).

ScalarIndexResults: add GetCandidateBitmap() + Cardinality() accessors so filter-first avoids materializing the candidate set into a vector.

Integration tests: extend test_module_filter / test_module_space / test_vector_index_flat and shared utils to cover RocksDB FLAT create/search/filter scenarios.