### PR TITLE
feat: SCAN fallback for composite scalar index

### DIFF
--- a/internal/engine/search/engine.cc
+++ b/internal/engine/search/engine.cc
@@ -466,7 +466,7 @@ Status Engine::Query(QueryRequest &request, Response &response_results) {
       filters[idx].upper_value = filter.upper_value;
       filters[idx].include_lower = filter.include_lower;
       filters[idx].include_upper = filter.include_upper;
-      filters[idx].is_union = static_cast<FilterOperator>(filter.is_union);
+      filters[idx].filter_operator = static_cast<FilterOperator>(filter.is_union);
 
       ++idx;
     }
@@ -476,7 +476,7 @@ Status Engine::Query(QueryRequest &request, Response &response_results) {
 
       filters[idx].field = table_->GetAttrIdx(filter.field);
       filters[idx].lower_value = filter.value;
-      filters[idx].is_union = static_cast<FilterOperator>(filter.is_union);
+      filters[idx].filter_operator = static_cast<FilterOperator>(filter.is_union);
 
       ++idx;
     }
@@ -543,7 +543,7 @@ int64_t Engine::ScalarIndexQuery(Request &request, SearchCondition *condition,
     filters[idx].upper_value = filter.upper_value;
     filters[idx].include_lower = filter.include_lower;
     filters[idx].include_upper = filter.include_upper;
-    filters[idx].is_union = static_cast<FilterOperator>(filter.is_union);
+    filters[idx].filter_operator = static_cast<FilterOperator>(filter.is_union);
 
     ++idx;
   }
@@ -553,7 +553,7 @@ int64_t Engine::ScalarIndexQuery(Request &request, SearchCondition *condition,
 
     filters[idx].field = table_->GetAttrIdx(filter.field);
     filters[idx].lower_value = filter.value;
-    filters[idx].is_union = static_cast<FilterOperator>(filter.is_union);
+    filters[idx].filter_operator = static_cast<FilterOperator>(filter.is_union);
 
     ++idx;
   }
@@ -754,12 +754,12 @@ int Engine::AddOrUpdate(Doc &doc) {
       indexing_state_.load() == IndexingState::IDLE and
       index_status_ == UNINDEXED) {
     if (vec_manager_ != nullptr && vec_manager_->SupportIncrement()) {
-    if (max_docid_ - delete_num_ >= training_threshold_) {
-      LOG(INFO) << space_name_ << " begin indexing. training_threshold="
-                << training_threshold_;
-      this->BuildIndex();
+      if (max_docid_ - delete_num_ >= training_threshold_) {
+        LOG(INFO) << space_name_ << " begin indexing. training_threshold="
+                  << training_threshold_;
+        this->BuildIndex();
+      }
     }
-  }
   }
 #ifdef PERFORMANCE_TESTING
   double end = utils::getmillisecs();
@@ -885,11 +885,11 @@ int Engine::Delete(std::string &key) {
 
   vec_manager_->Delete(docid);
   is_dirty_ = true;
+
   if (vec_manager_ != nullptr &&
       !vec_manager_->SupportIncrement() && index_status_ == INDEXED) {
     return 1;
   }
-
   return ret;
 }
 
@@ -1376,12 +1376,12 @@ int Engine::Load() {
       indexing_state_.load() == IndexingState::IDLE and
       index_status_ == UNINDEXED) {
     if (vec_manager_ != nullptr && vec_manager_->SupportIncrement()) {
-    if (max_docid_ - delete_num_ >= training_threshold_) {
-      LOG(INFO) << space_name_ << " begin indexing. training_threshold="
-                << training_threshold_;
-      this->BuildIndex();
+      if (max_docid_ - delete_num_ >= training_threshold_) {
+        LOG(INFO) << space_name_ << " begin indexing. training_threshold="
+                  << training_threshold_;
+        this->BuildIndex();
+      }
     }
-  }
   }
   // remove directorys which are not done
   for (const std::string &folder : folders_not_done) {

--- a/internal/engine/table/composite_index.cc
+++ b/internal/engine/table/composite_index.cc
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <unordered_set>
 #include <unordered_map>
-#include <iomanip>
 
 #include "inverted_index.h"
 #include "scalar_index_utils.h"
@@ -382,14 +381,6 @@ ScalarIndexResult CompositeIndex::Equal(const std::vector<std::string>& prefix_v
   return result;
 }
 
-std::string toHexString(const std::string& binary) {
-  std::ostringstream oss;
-  for (unsigned char c : binary) {
-      oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c);
-  }
-  return oss.str();
-}
-
 ScalarIndexResult CompositeIndex::Range(const std::vector<std::string>& prefix_values,
                                        const std::string& lower_value,
                                        const std::string& upper_value,
@@ -546,6 +537,528 @@ ScalarIndexResult CompositeIndex::In(const std::vector<std::string>& prefix_valu
     return ScalarIndexResult(combined_result, offset, limit);
   }
   return combined_result;
+}
+
+bool CompositeIndex::CanUseScan(const std::vector<int>& query_field_ids,
+                                const std::vector<CompositeFilterMode>& modes) const {
+  if (query_field_ids.empty() || query_field_ids.size() != modes.size()) {
+    return false;
+  }
+  std::unordered_set<int> idx_set(field_ids_.begin(), field_ids_.end());
+  for (int f : query_field_ids) {
+    if (idx_set.find(f) == idx_set.end()) return false;
+  }
+  // All modes in the enum are point-decidable; reject nothing here, but keep
+  // the gate so future None / wildcard modes are explicitly excluded.
+  for (auto m : modes) {
+    switch (m) {
+      case CompositeFilterMode::Equal:
+      case CompositeFilterMode::NotEqual:
+      case CompositeFilterMode::In:
+      case CompositeFilterMode::NotIn:
+      case CompositeFilterMode::Range:
+        break;
+      default:
+        return false;
+    }
+  }
+  return true;
+}
+
+namespace {
+
+// Pull the i-th field value out of a composite key body (the bytes between
+// header and trailing docid). Returns false on malformed key. On success
+// `cursor` advances past the consumed bytes and `out` holds the raw value:
+//   numeric: sortable bytes (caller compares against sortable filter bounds)
+//   string : raw content (length prefix stripped)
+bool ExtractField(const std::string& body, size_t& cursor,
+                  enum DataType dtype, std::string& out) {
+  switch (dtype) {
+    case DataType::INT:
+    case DataType::FLOAT: {
+      constexpr size_t kBytes = sizeof(int32_t);
+      if (cursor + kBytes > body.size()) return false;
+      out.assign(body, cursor, kBytes);
+      cursor += kBytes;
+      return true;
+    }
+    case DataType::LONG:
+    case DataType::DATE:
+    case DataType::DOUBLE: {
+      constexpr size_t kBytes = sizeof(int64_t);
+      if (cursor + kBytes > body.size()) return false;
+      out.assign(body, cursor, kBytes);
+      cursor += kBytes;
+      return true;
+    }
+    case DataType::STRING:
+    case DataType::STRINGARRAY: {
+      if (cursor + kStringLenBytes > body.size()) return false;
+      uint32_t len = 0;
+      for (size_t i = 0; i < kStringLenBytes; ++i) {
+        len = (len << 8) | static_cast<uint8_t>(body[cursor + i]);
+      }
+      cursor += kStringLenBytes;
+      if (cursor + len > body.size()) return false;
+      out.assign(body, cursor, len);
+      cursor += len;
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+// Apply one filter to one entry's raw field value. For numeric fields the
+// raw value is sortable bytes; we compare directly against pre-encoded
+// filter bounds (caller is responsible for encoding lower/upper the same
+// way). For string fields, raw is the literal content.
+bool MatchOne(const std::string& raw,
+              enum DataType dtype,
+              const FilterInfo& filter,
+              const std::string& enc_lower,
+              const std::string& enc_upper,
+              const std::vector<std::string>* string_in_items) {
+  if (dtype == DataType::STRING || dtype == DataType::STRINGARRAY) {
+    if (string_in_items == nullptr) return false;
+    bool found = false;
+    for (const auto& item : *string_in_items) {
+      if (raw == item) { found = true; break; }
+    }
+    if (filter.filter_operator == FilterOperator::Not) return !found;
+    return found;
+  }
+  // Numeric: raw is already sortable, so memcmp gives correct order.
+  // Equal: raw == enc_lower (enc_lower == enc_upper, both inclusive)
+  // NotEqual: raw != enc_lower
+  // Range: lower <= raw <= upper, with inclusive flags
+  bool eq_bounds = (enc_lower == enc_upper);
+  if (eq_bounds && filter.include_lower && filter.include_upper) {
+    bool eq = (raw == enc_lower);
+    if (filter.filter_operator == FilterOperator::Not) return !eq;
+    return eq;
+  }
+  if (!enc_lower.empty()) {
+    if (filter.include_lower) {
+      if (raw < enc_lower) return false;
+    } else {
+      if (raw <= enc_lower) return false;
+    }
+  }
+  if (!enc_upper.empty()) {
+    if (filter.include_upper) {
+      if (raw > enc_upper) return false;
+    } else {
+      if (raw >= enc_upper) return false;
+    }
+  }
+  return true;
+}
+
+// ============================================================================
+// Scan: internal helpers
+// ============================================================================
+
+// Precomputed view of a FilterInfo against this composite index: which
+// position in field_ids_ it constrains, its data type, and any sortable-
+// encoded bounds / split items that the per-entry evaluator will want.
+struct PreparedFilter {
+  int idx_pos;             // position in field_ids_
+  enum DataType dtype;
+  const FilterInfo* fi;
+  std::string enc_lower;   // sortable-encoded lower bound (numeric)
+  std::string enc_upper;   // sortable-encoded upper bound (numeric)
+  std::vector<std::string> string_items;  // split for IN/NotIn
+};
+
+// One contiguous RocksDB iterator range that the segmented scan visits.
+struct ScanSegment {
+  std::string seek_start;    // iter->Seek target
+  std::string prefix_match;  // require key.starts_with(prefix_match)
+  // Optional upper-bound short-circuit: applies to the raw bytes
+  // extracted at position upper_pos. Empty enc_upper disables.
+  int upper_pos = -1;
+  std::string enc_upper;
+  bool include_upper = true;
+};
+
+constexpr size_t kInSegmentThreshold = 16;
+
+// Resolve every filter against the composite layout, dropping filters whose
+// field isn't part of this index. Numeric bounds are sortable-encoded once
+// here so the hot loop only has to memcmp.
+std::vector<PreparedFilter> PrepareFilters(
+    const std::vector<FilterInfo>& filters,
+    const std::vector<int>& field_ids,
+    const std::vector<enum DataType>& data_types) {
+  std::vector<PreparedFilter> prepared;
+  prepared.reserve(filters.size());
+  for (const auto& f : filters) {
+    auto it = std::find(field_ids.begin(), field_ids.end(), f.field);
+    if (it == field_ids.end()) {
+      LOG(WARNING) << "Scan: filter field " << f.field
+                   << " not in composite, skip filter";
+      continue;
+    }
+    PreparedFilter pf;
+    pf.idx_pos = static_cast<int>(it - field_ids.begin());
+    pf.dtype = data_types[pf.idx_pos];
+    pf.fi = &f;
+    if (pf.dtype == DataType::STRING || pf.dtype == DataType::STRINGARRAY) {
+      pf.string_items = utils::split(f.lower_value, kStringArrayValueDelimiter);
+    } else {
+      if (!f.lower_value.empty()) {
+        pf.enc_lower = EncodeSortableValue(pf.dtype, f.lower_value);
+      }
+      if (!f.upper_value.empty()) {
+        pf.enc_upper = EncodeSortableValue(pf.dtype, f.upper_value);
+      }
+    }
+    prepared.push_back(std::move(pf));
+  }
+  return prepared;
+}
+
+// True iff any field in this composite is STRINGARRAY. When true, multiple
+// RocksDB entries can share one docid (cartesian expansion), so the scan
+// must aggregate per-docid before evaluating NOT IN / IN semantics.
+bool HasStringArray(const std::vector<enum DataType>& data_types) {
+  for (auto dt : data_types) {
+    if (dt == DataType::STRINGARRAY) return true;
+  }
+  return false;
+}
+
+// Build the longest leading-Equal seek prefix: walk field_ids from position
+// 0 and append encoded values for each consecutive position whose filter
+// pins the field to a single value. The first position NOT covered is
+// returned in `out_next_pos`.
+//
+// Anything that breaks the chain (no filter, negation, range, multi-value
+// IN, ambiguous STRINGARRAY case, or OR semantics across filters) stops
+// the prefix at that point; remaining fields still get evaluated via the
+// existing per-entry / per-docid aggregation path.
+//
+// STRINGARRAY rule: each doc with an N-element array writes N RocksDB
+// entries (cartesian-expanded over other STRINGARRAY fields too). A prefix
+// on a STRINGARRAY position would skip the doc's other-element rows. That
+// is safe iff:
+//   1. the field is constrained by exactly one filter in this query, AND
+//   2. that filter is positive single-value (IN with one item or "=").
+// Otherwise the per-docid aggregated view would be missing values that
+// live in skipped segments, leading to wrong results. Multi-value IN can
+// be safely handled via multi-segment sub-scans below; that path is taken
+// when the prefix chain ends, not here.
+std::string BuildEqualPrefix(const std::string& header_key,
+                             const std::vector<int>& field_ids,
+                             const std::vector<PreparedFilter>& prepared,
+                             FilterOperator inner_op,
+                             size_t* out_next_pos) {
+  std::string equal_prefix = header_key;
+  size_t next_pos = 0;
+  if (inner_op != FilterOperator::And) {
+    *out_next_pos = next_pos;
+    return equal_prefix;
+  }
+
+  std::unordered_map<int, int> pos_filter_count;
+  std::unordered_map<int, const PreparedFilter*> by_pos;
+  for (const auto& pf : prepared) {
+    pos_filter_count[pf.idx_pos]++;
+    by_pos.emplace(pf.idx_pos, &pf);
+  }
+
+  for (size_t pos = 0; pos < field_ids.size(); ++pos) {
+    auto it = by_pos.find(static_cast<int>(pos));
+    if (it == by_pos.end()) break;
+    const PreparedFilter* pf = it->second;
+    if (pf->fi->filter_operator == FilterOperator::Not) break;
+    if (pf->dtype == DataType::STRINGARRAY) {
+      if (pos_filter_count[pf->idx_pos] != 1) break;
+      if (pf->string_items.size() != 1) break;
+      equal_prefix += EncodeSortableValue(pf->dtype, pf->string_items[0]);
+    } else if (pf->dtype == DataType::STRING) {
+      if (pf->string_items.size() != 1) break;
+      equal_prefix += EncodeSortableValue(pf->dtype, pf->string_items[0]);
+    } else {
+      if (pf->enc_lower.empty() || pf->enc_lower != pf->enc_upper) break;
+      if (!pf->fi->include_lower || !pf->fi->include_upper) break;
+      equal_prefix += pf->enc_lower;
+    }
+    next_pos = pos + 1;
+  }
+  *out_next_pos = next_pos;
+  return equal_prefix;
+}
+
+// Derive scan segments from equal_prefix + the next field's filter, if one
+// exists and is amenable to further narrowing:
+//   * IN with <= kInSegmentThreshold values  -> N segments, one per value
+//   * Range with a lower bound               -> 1 segment, start at lower,
+//                                               early-break when this field
+//                                               exceeds the encoded upper.
+//   * Anything else                          -> 1 segment == equal_prefix
+std::vector<ScanSegment> BuildScanSegments(
+    const std::string& equal_prefix,
+    size_t equal_prefix_pos,
+    const std::vector<int>& field_ids,
+    const std::vector<PreparedFilter>& prepared,
+    FilterOperator inner_op) {
+  std::vector<ScanSegment> segments;
+
+  if (inner_op == FilterOperator::And &&
+      equal_prefix_pos < field_ids.size()) {
+    const PreparedFilter* next_pf = nullptr;
+    for (const auto& pf : prepared) {
+      if (pf.idx_pos == static_cast<int>(equal_prefix_pos)) {
+        next_pf = &pf;
+        break;
+      }
+    }
+    if (next_pf != nullptr &&
+        next_pf->fi->filter_operator != FilterOperator::Not &&
+        next_pf->dtype != DataType::STRINGARRAY) {
+      bool is_string_in =
+          (next_pf->dtype == DataType::STRING) &&
+          next_pf->string_items.size() >= 2 &&
+          next_pf->string_items.size() <= kInSegmentThreshold;
+      // Numeric Range path: has a lower bound; upper may be empty.
+      bool is_numeric_range =
+          (next_pf->dtype != DataType::STRING) &&
+          !next_pf->enc_lower.empty();
+      if (is_string_in) {
+        segments.reserve(next_pf->string_items.size());
+        for (const auto& item : next_pf->string_items) {
+          ScanSegment s;
+          s.seek_start = equal_prefix + EncodeSortableValue(next_pf->dtype, item);
+          s.prefix_match = s.seek_start;
+          segments.push_back(std::move(s));
+        }
+      } else if (is_numeric_range) {
+        ScanSegment s;
+        s.seek_start = equal_prefix + next_pf->enc_lower;
+        s.prefix_match = equal_prefix;
+        s.upper_pos = static_cast<int>(equal_prefix_pos);
+        s.enc_upper = next_pf->enc_upper;  // may be empty (open upper)
+        s.include_upper = next_pf->fi->include_upper;
+        segments.push_back(std::move(s));
+      }
+    }
+  }
+
+  if (segments.empty()) {
+    ScanSegment s;
+    s.seek_start = equal_prefix;
+    s.prefix_match = equal_prefix;
+    segments.push_back(std::move(s));
+  }
+  return segments;
+}
+
+// Decode each composite field's raw value from a RocksDB key body. Returns
+// false on malformed key (caller should skip it).
+bool DecodeKeyFields(const std::string& key,
+                     size_t header_len,
+                     const std::vector<enum DataType>& data_types,
+                     std::vector<std::string>* raw_vals) {
+  if (key.size() < header_len + sizeof(int64_t)) return false;
+  size_t body_end = key.size() - sizeof(int64_t);
+  std::string body(key.data() + header_len, body_end - header_len);
+  size_t cursor = 0;
+  raw_vals->assign(data_types.size(), {});
+  for (size_t i = 0; i < data_types.size(); ++i) {
+    if (!ExtractField(body, cursor, data_types[i], (*raw_vals)[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Per-docid filter evaluation. For STRINGARRAY-bearing composites the
+// caller has aggregated every observed value for the field; semantics:
+//   - IN  (Or):  match iff ANY observed value is in the IN list.
+//   - NotIn(Not): match iff NO observed value is in the list.
+//   - Range/Equal/NotEqual (numeric): same any/none rules.
+bool EvalFilterForDocid(const PreparedFilter& pf,
+                        const std::vector<std::string>& values) {
+  if (values.empty()) return false;
+  if (pf.dtype == DataType::STRING || pf.dtype == DataType::STRINGARRAY) {
+    bool any_in_list = false;
+    for (const auto& v : values) {
+      for (const auto& item : pf.string_items) {
+        if (v == item) { any_in_list = true; break; }
+      }
+      if (any_in_list) break;
+    }
+    if (pf.fi->filter_operator == FilterOperator::Not) return !any_in_list;
+    return any_in_list;
+  }
+  bool eq_bounds = (pf.enc_lower == pf.enc_upper);
+  if (eq_bounds && pf.fi->include_lower && pf.fi->include_upper) {
+    bool any_eq = false;
+    for (const auto& v : values) {
+      if (v == pf.enc_lower) { any_eq = true; break; }
+    }
+    if (pf.fi->filter_operator == FilterOperator::Not) return !any_eq;
+    return any_eq;
+  }
+  for (const auto& v : values) {
+    if (!pf.enc_lower.empty()) {
+      if (pf.fi->include_lower) { if (v < pf.enc_lower) continue; }
+      else { if (v <= pf.enc_lower) continue; }
+    }
+    if (!pf.enc_upper.empty()) {
+      if (pf.fi->include_upper) { if (v > pf.enc_upper) continue; }
+      else { if (v >= pf.enc_upper) continue; }
+    }
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+ScalarIndexResult CompositeIndex::Scan(const std::vector<FilterInfo>& filters,
+                                       FilterOperator inner_op,
+                                       int offset, int limit) {
+  ScalarIndexResult result;
+
+  auto prepared = PrepareFilters(filters, field_ids_, data_types_);
+  if (prepared.empty()) return result;
+
+  const bool has_stringarray = HasStringArray(data_types_);
+
+  size_t equal_prefix_pos = 0;
+  std::string equal_prefix = BuildEqualPrefix(
+      header_key_, field_ids_, prepared, inner_op, &equal_prefix_pos);
+
+  auto segments = BuildScanSegments(
+      equal_prefix, equal_prefix_pos, field_ids_, prepared, inner_op);
+
+  // Field positions referenced by prepared filters; only these are aggregated
+  // in the STRINGARRAY path.
+  std::unordered_set<int> needed_positions;
+  for (const auto& pf : prepared) needed_positions.insert(pf.idx_pos);
+
+  auto& db = storage_mgr_->GetDB();
+  rocksdb::ColumnFamilyHandle* cf_handler = CfHandler();
+  rocksdb::ReadOptions read_options;
+  std::unique_ptr<rocksdb::Iterator> iter(db->NewIterator(read_options, cf_handler));
+
+  const size_t header_len = header_key_.size();
+  size_t matched = 0;
+  int skipped = 0;
+
+  // STRINGARRAY aggregation buffer: docid -> per-position observed values.
+  std::unordered_map<int64_t, std::vector<std::vector<std::string>>> agg;
+  std::unordered_set<int64_t> emitted;
+
+  auto try_emit = [&](int64_t docid) -> bool {
+    if (emitted.count(docid)) return false;
+    emitted.insert(docid);
+    if (skipped < offset) { ++skipped; return false; }
+    result.Add(docid);
+    ++matched;
+    return true;
+  };
+
+  auto flush_docid = [&](int64_t docid) -> bool {
+    auto it = agg.find(docid);
+    if (it == agg.end()) return false;
+    const auto& per_pos = it->second;
+    bool hit = (inner_op == FilterOperator::And);
+    for (const auto& pf : prepared) {
+      bool m = EvalFilterForDocid(pf, per_pos[pf.idx_pos]);
+      if (inner_op == FilterOperator::And) {
+        if (!m) { hit = false; break; }
+      } else {
+        if (m) { hit = true; break; }
+        hit = false;
+      }
+    }
+    agg.erase(it);
+    if (!hit) return false;
+    return try_emit(docid);
+  };
+
+  bool reached_limit = false;
+  std::vector<std::string> raw_vals;
+  for (const auto& seg : segments) {
+    if (reached_limit) break;
+    for (iter->Seek(seg.seek_start);
+         iter->Valid() && iter->key().starts_with(seg.prefix_match);
+         iter->Next()) {
+      std::string key = iter->key().ToString();
+      if (!DecodeKeyFields(key, header_len, data_types_, &raw_vals)) continue;
+
+      // Range upper-bound short-circuit: keys within the same prefix_match
+      // are sorted by this field's sortable encoding, so once we move past
+      // enc_upper we can stop the segment entirely.
+      if (seg.upper_pos >= 0 && !seg.enc_upper.empty()) {
+        const std::string& v = raw_vals[seg.upper_pos];
+        bool past = seg.include_upper ? (v > seg.enc_upper)
+                                       : (v >= seg.enc_upper);
+        if (past) break;
+      }
+
+      int64_t docid = DecodeDocidFromBinaryKey(key);
+      if (docid < 0) continue;
+
+      if (!has_stringarray) {
+        // Fast path: one entry per docid, evaluate inline against the key.
+        bool hit = (inner_op == FilterOperator::And);
+        for (const auto& pf : prepared) {
+          bool m = MatchOne(raw_vals[pf.idx_pos], pf.dtype, *pf.fi,
+                            pf.enc_lower, pf.enc_upper,
+                            (pf.dtype == DataType::STRING ||
+                             pf.dtype == DataType::STRINGARRAY)
+                                ? &pf.string_items : nullptr);
+          if (inner_op == FilterOperator::And) {
+            if (!m) { hit = false; break; }
+          } else {
+            if (m) { hit = true; break; }
+            hit = false;
+          }
+        }
+        if (!hit) continue;
+        if (!try_emit(docid)) continue;
+        if (limit > 0 && static_cast<int>(matched) >= limit) {
+          reached_limit = true;
+          break;
+        }
+        continue;
+      }
+
+      // STRINGARRAY path: accumulate; defer evaluation to the post-loop flush
+      // because a later entry for the same docid can contribute a value that
+      // flips a NOT IN result.
+      auto& per_pos = agg[docid];
+      if (per_pos.empty()) per_pos.assign(field_ids_.size(), {});
+      for (int pos : needed_positions) {
+        auto& bucket = per_pos[pos];
+        const std::string& v = raw_vals[pos];
+        bool dup = false;
+        for (const auto& existing : bucket) {
+          if (existing == v) { dup = true; break; }
+        }
+        if (!dup) bucket.push_back(v);
+      }
+    }
+  }
+
+  if (has_stringarray) {
+    std::vector<int64_t> docids;
+    docids.reserve(agg.size());
+    for (auto& kv : agg) docids.push_back(kv.first);
+    std::sort(docids.begin(), docids.end());
+    for (int64_t docid : docids) {
+      flush_docid(docid);
+      if (limit > 0 && static_cast<int>(matched) >= limit) break;
+    }
+  }
+
+  return result;
 }
 
 } // namespace vearch

--- a/internal/engine/table/composite_index.h
+++ b/internal/engine/table/composite_index.h
@@ -120,6 +120,46 @@ class CompositeIndex : public InvertedIndex {
 
   bool CanUseFilterMode(const std::vector<int>& field_ids, const std::vector<CompositeFilterMode>& modes, CompositeStrategy& strategy);
 
+  /**
+   * Check whether the given filter fields can be served by SCAN fallback.
+   * SCAN does not require fields to form a key prefix; it iterates every
+   * entry of the composite index and applies filters per entry.
+   *
+   * Requirements:
+   *   - every query field must belong to this composite index
+   *   - every mode must be point-decidable (Equal / Range / In / NotIn / NotEqual)
+   *
+   * @param query_field_ids fields appearing in the query (any order, may
+   *                        repeat — e.g. OR-of-equals on the same field).
+   * @param modes           corresponding filter modes, parallel to
+   *                        query_field_ids.
+   */
+  bool CanUseScan(const std::vector<int>& query_field_ids,
+                  const std::vector<CompositeFilterMode>& modes) const;
+
+  /**
+   * Filter scan over this composite index.
+   *
+   * Logically equivalent to iterating every entry under the composite
+   * header, decoding each field value from the key, evaluating the
+   * filters, and emitting matching docids. Internally narrows the
+   * iterated range when the filter set permits: builds a leading-Equal
+   * seek prefix from consecutive AND filters that pin a single value,
+   * and may further split into per-value sub-scans (string IN) or a
+   * range-bounded sub-scan (numeric Range). Cases that would compromise
+   * per-docid aggregation (OR semantics, NotEqual / NotIn, multi-filter
+   * on the same STRINGARRAY field) fall back to the full header scan.
+   * Duplicates produced by STRINGARRAY cartesian expansion are folded
+   * by ScalarIndexResult::Add.
+   *
+   * @param filters  filters to evaluate; field ids must belong to this index.
+   * @param inner_op AND -> every filter must match; OR -> any filter matches.
+   * @param offset/limit  applied to the final result set (post-filter).
+   */
+  ScalarIndexResult Scan(const std::vector<FilterInfo>& filters,
+                         FilterOperator inner_op,
+                         int offset, int limit);
+
   std::string GetHeaderKey() const { return header_key_; }
 
   // Override InvertedIndex's key helpers with composite binary format:

--- a/internal/engine/table/scalar_index_manager.cc
+++ b/internal/engine/table/scalar_index_manager.cc
@@ -303,7 +303,7 @@ int ScalarIndexManager::Filter(ScalarIndex* scalar_idx, const FilterInfo &filter
       return 0;
     }
     if (filter.lower_value == filter.upper_value) {
-      if (filter.is_union == FilterOperator::Not) {
+      if (filter.filter_operator == FilterOperator::Not) {
         result = scalar_idx->NotEqual(filter.lower_value, offset, limit);
       } else {
         result = scalar_idx->Equal(filter.lower_value, offset, limit);
@@ -335,7 +335,7 @@ int ScalarIndexManager::Filter(ScalarIndex* scalar_idx, const FilterInfo &filter
     }
     std::vector<std::string> items;
     items = utils::split(filter.lower_value, kStringArrayValueDelimiter);
-    if (filter.is_union == FilterOperator::Not) {
+    if (filter.filter_operator == FilterOperator::Not) {
       result = scalar_idx->NotIn(items, offset, limit);
     } else {
       result = scalar_idx->In(items, offset, limit);
@@ -367,7 +367,7 @@ static ScalarIndex* GetCompositeIndexByFieldId(int field_id, const std::map<std:
 // Determine the filter mode for composite index matching.
 // Supports:
 //   - Equal (=): lower_value == upper_value, both inclusive
-//   - In (IN): for STRING/STRINGARRAY fields, is_union==Or with lower_value containing values
+//   - In (IN): for STRING/STRINGARRAY fields, filter_operator==Or with lower_value containing values
 //   - Range (>=, <=, >, <): for numeric fields (INT, LONG, FLOAT, DOUBLE, DATE)
 static bool GetFilterMode(const FilterInfo& filter, Table* table, CompositeFilterMode& out_mode) {
   DataType dtype;
@@ -379,26 +379,26 @@ static bool GetFilterMode(const FilterInfo& filter, Table* table, CompositeFilte
 
   // STRING/STRINGARRAY: IN or NotIn query mode
   if (dtype == DataType::STRING || dtype == DataType::STRINGARRAY) {
-    // IN query: is_union == Or, lower_value contains the values
-    if (filter.is_union == FilterOperator::Or && !filter.lower_value.empty()) {
+    // IN query: filter_operator == Or, lower_value contains the values
+    if (filter.filter_operator == FilterOperator::Or && !filter.lower_value.empty()) {
       out_mode = CompositeFilterMode::In;
       return true;
     }
-    // NotIn query: is_union == Not, lower_value contains the excluded values
-    if (filter.is_union == FilterOperator::Not && !filter.lower_value.empty()) {
+    // NotIn query: filter_operator == Not, lower_value contains the excluded values
+    if (filter.filter_operator == FilterOperator::Not && !filter.lower_value.empty()) {
       out_mode = CompositeFilterMode::NotIn;
       return true;
     }
     // Not supported for STRING
-    LOG(WARNING) << "GetFilterMode: unsupported STRING filter mode, is_union="
-                 << static_cast<int>(filter.is_union)
+    LOG(WARNING) << "GetFilterMode: unsupported STRING filter mode, filter_operator="
+                 << static_cast<int>(filter.filter_operator)
                  << ", lower_value.empty=" << filter.lower_value.empty();
     return false;
   }
 
   // Numeric fields
-  // NotEqual: single-value Not query (lower_value == upper_value, both inclusive, is_union == Not)
-  if (filter.is_union == FilterOperator::Not &&
+  // NotEqual: single-value Not query (lower_value == upper_value, both inclusive, filter_operator == Not)
+  if (filter.filter_operator == FilterOperator::Not &&
       filter.lower_value == filter.upper_value &&
       filter.include_lower && filter.include_upper) {
     out_mode = CompositeFilterMode::NotEqual;
@@ -406,7 +406,7 @@ static bool GetFilterMode(const FilterInfo& filter, Table* table, CompositeFilte
   }
   bool is_range = (filter.lower_value != filter.upper_value) ||
                   !filter.include_lower || !filter.include_upper ||
-                  filter.is_union == FilterOperator::Not;
+                  filter.filter_operator == FilterOperator::Not;
   if (is_range) {
     out_mode = CompositeFilterMode::Range;
     return true;
@@ -434,6 +434,11 @@ int ScalarIndexManager::CompositeFilter(CompositeIndex* composite_idx, const std
     case CompositeStrategy::NOT_EQUAL:
       ExecuteNotEqualCase(composite_idx, filters[0], result);
       break;
+    case CompositeStrategy::SCAN:
+      // Default to AND. OR-bucket SCANs go through ExecuteScanCase
+      // directly from the Search loop.
+      ExecuteScanCase(composite_idx, filters, FilterOperator::And, result);
+      break;
     default:
       LOG(WARNING) << "Unknown composite strategy, skipping";
   }
@@ -444,7 +449,11 @@ bool CanUseCompositeFilter(CompositeIndex* composite, Table* table,
   const std::vector<FilterInfo>& filters, CompositeStrategy& strategy) {
   std::vector<int> field_ids;
   std::vector<CompositeFilterMode> modes;
+  std::set<int> seen;
   for (const auto& filter : filters) {
+    if (!seen.insert(filter.field).second) {
+      return false;
+    }
     field_ids.push_back(filter.field);
     CompositeFilterMode mode;
     if (!GetFilterMode(filter, table, mode)) {
@@ -456,6 +465,162 @@ bool CanUseCompositeFilter(CompositeIndex* composite, Table* table,
   return composite->CanUseFilterMode(field_ids, modes, strategy);
 }
 
+namespace {
+
+// Plan chosen for a single composite index in the AND branch.
+struct ChosenPlan {
+  std::vector<FilterInfo> filters;
+  CompositeStrategy strategy;
+};
+
+// Build per-composite filter views for the AND branch:
+//   prefix_out: continuous prefix from the composite's fid order, used by the
+//     legacy EQUAL / RANGE / IN strategies (requires CanUseCompositeFilter).
+//   all_out:   every query filter whose field belongs to this composite,
+//     regardless of order or duplicates; used as the SCAN fallback input.
+static void BuildCompositeViews(
+    const std::vector<FilterInfo>& filters,
+    const std::map<std::string, std::shared_ptr<CompositeIndex>>& composite_indexes,
+    std::map<CompositeIndex*, std::vector<FilterInfo>>& prefix_out,
+    std::map<CompositeIndex*, std::vector<FilterInfo>>& all_out) {
+  for (auto& composite_index : composite_indexes) {
+    CompositeIndex* idx = composite_index.second.get();
+    const std::vector<int>& idx_fields = idx->GetFieldIds();
+
+    std::vector<FilterInfo> prefix_filters;
+    for (size_t i = 0; i < idx_fields.size(); ++i) {
+      int cf = idx_fields[i];
+      std::vector<FilterInfo> field_filters;
+      for (size_t j = 0; j < filters.size(); ++j) {
+        if (filters[j].field == cf) {
+          field_filters.push_back(filters[j]);
+        }
+      }
+      if (field_filters.empty()) {
+        break;
+      }
+      prefix_filters.insert(prefix_filters.end(), field_filters.begin(), field_filters.end());
+    }
+    if (!prefix_filters.empty()) {
+      prefix_out[idx] = std::move(prefix_filters);
+    }
+
+    std::vector<FilterInfo> all_filters;
+    for (const auto& f : filters) {
+      if (idx->IsIndexField(f.field)) {
+        all_filters.push_back(f);
+      }
+    }
+    if (!all_filters.empty()) {
+      all_out[idx] = std::move(all_filters);
+    }
+  }
+}
+
+// For each composite index that owns some query field, pick a plan: prefix
+// strategy when it covers every candidate field, else SCAN over all candidate
+// filters. Composites that cannot serve either path are skipped.
+static void ChoosePerCompositeStrategy(
+    const std::map<CompositeIndex*, std::vector<FilterInfo>>& prefix_filters_for_idx,
+    const std::map<CompositeIndex*, std::vector<FilterInfo>>& all_filters_for_idx,
+    Table* table,
+    std::map<CompositeIndex*, ChosenPlan>& chosen) {
+  for (const auto& kv : all_filters_for_idx) {
+    CompositeIndex* idx = kv.first;
+    const std::vector<FilterInfo>& all_f = kv.second;
+
+    std::set<int> all_fields;
+    for (const auto& f : all_f) all_fields.insert(f.field);
+
+    auto pf_it = prefix_filters_for_idx.find(idx);
+    if (pf_it != prefix_filters_for_idx.end()) {
+      CompositeStrategy strategy = CompositeStrategy::NONE;
+      std::set<int> prefix_fields;
+      for (const auto& f : pf_it->second) prefix_fields.insert(f.field);
+
+      bool prefix_covers_all = (prefix_fields == all_fields);
+      if (prefix_covers_all &&
+          CanUseCompositeFilter(idx, table, pf_it->second, strategy)) {
+        chosen[idx] = {pf_it->second, strategy};
+        continue;
+      }
+    }
+
+    // Fallback to SCAN.
+    std::vector<int> qf_ids;
+    std::vector<CompositeFilterMode> modes;
+    bool ok = true;
+    for (const auto& f : all_f) {
+      CompositeFilterMode m;
+      if (!GetFilterMode(f, table, m)) { ok = false; break; }
+      qf_ids.push_back(f.field);
+      modes.push_back(m);
+    }
+    if (ok && idx->CanUseScan(qf_ids, modes)) {
+      chosen[idx] = {all_f, CompositeStrategy::SCAN};
+    }
+  }
+}
+
+}  // namespace
+
+// OR branch: prefix strategies can't be combined safely across filter buckets
+// when some bucket would Union with a *partial* result. Build per-filter pairs:
+// scalar where available, else SCAN-bucket on a composite that owns the field.
+// Fail when a field has no index at all.
+int ScalarIndexManager::OrganizeFiltersForOr(
+    const std::vector<FilterInfo>& filters,
+    std::vector<FilterIndexPair>& filter_index_pairs) {
+  std::map<CompositeIndex*, std::vector<FilterInfo>> or_scan_buckets;
+  for (const auto& f : filters) {
+    if (auto sidx = GetFieldIndex(f.field)) {
+      FilterIndexPair pair;
+      pair.index = sidx;
+      pair.filters = {f};
+      pair.is_composite = false;
+      filter_index_pairs.push_back(std::move(pair));
+      continue;
+    }
+    // No scalar index: find a composite that owns this field.
+    CompositeIndex* host = nullptr;
+    for (auto& kv : composite_indexes_) {
+      if (kv.second->IsIndexField(f.field)) {
+        host = kv.second.get();
+        break;
+      }
+    }
+    if (host == nullptr) {
+      // Field has no index at all -> OR cannot be satisfied via indexes.
+      return -1;
+    }
+    or_scan_buckets[host].push_back(f);
+  }
+  for (auto& kv : or_scan_buckets) {
+    // Verify SCAN is applicable for this bucket.
+    std::vector<int> field_ids;
+    std::vector<CompositeFilterMode> modes;
+    bool ok = true;
+    for (const auto& f : kv.second) {
+      CompositeFilterMode m;
+      if (!GetFilterMode(f, table_, m)) { ok = false; break; }
+      field_ids.push_back(f.field);
+      modes.push_back(m);
+    }
+    if (!ok || !kv.first->CanUseScan(field_ids, modes)) {
+      return -1;
+    }
+    FilterIndexPair pair;
+    pair.composite_index = kv.first;
+    pair.is_composite = true;
+    pair.filters = std::move(kv.second);
+    pair.strategy = CompositeStrategy::SCAN;
+    pair.inner_op = FilterOperator::Or;
+    filter_index_pairs.push_back(std::move(pair));
+  }
+  if (filter_index_pairs.empty()) return -1;
+  return 0;
+}
+
 int ScalarIndexManager::OrganizeFiltersToIndex(
   const std::vector<FilterInfo>& filters,
   std::vector<FilterIndexPair>& filter_index_pairs,
@@ -463,97 +628,64 @@ int ScalarIndexManager::OrganizeFiltersToIndex(
   if (filters.empty()) {
     return 0;
   }
-  std::vector<int> field_ids;
   std::set<int> wanted_execute_fields;
-  std::map<CompositeIndex*, std::vector<FilterInfo>> composite_filters;
   for (const auto& filter : filters) {
-    field_ids.push_back(filter.field);
     wanted_execute_fields.insert(filter.field);
   }
-  for (auto composite_index : composite_indexes_) {
-    for (size_t i = 0; i < field_ids.size(); i++) {
-      int field_id = field_ids[i];
-      if (composite_index.second->IsIndexField(field_id)) {
-        if (composite_filters.find(composite_index.second.get()) == composite_filters.end()) {
-          composite_filters[composite_index.second.get()] = std::vector<FilterInfo>();
-          composite_filters[composite_index.second.get()].push_back(filters[i]);
-        } else {
-          composite_filters[composite_index.second.get()].push_back(filters[i]);
-        }
-      }
-    }
-  }
-  // Sort filters according to CompositeIndex field order (not user query order).
-  for (auto& kv : composite_filters) {
-    CompositeIndex* idx = kv.first;
-    std::vector<int> idx_field_order = idx->GetFieldIds();
-    std::map<int, std::vector<FilterInfo>> field_to_filters;
-    for (const auto& f : kv.second) {
-      field_to_filters[f.field].push_back(f);
-    }
-    kv.second.clear();
-    for (int fid : idx_field_order) {
-      auto it = field_to_filters.find(fid);
-      if (it != field_to_filters.end()) {
-        for (const auto& f : it->second) {
-          kv.second.push_back(f);
-        }
-      }
-    }
-  }
-  std::map<CompositeIndex*, std::vector<FilterInfo>> usable_composite;
-  std::map<CompositeIndex*, CompositeStrategy> strategies;
-  std::set<int> composite_covered_fields;
-  for (const auto& kv : composite_filters) {
-    CompositeStrategy strategy = CompositeStrategy::NONE;
-    if (CanUseCompositeFilter(kv.first, table_, kv.second, strategy)) {
-      usable_composite[kv.first] = kv.second;
-      strategies[kv.first] = strategy;
-      for (const auto& f : kv.second) {
-        composite_covered_fields.insert(f.field);
-      }
-    }
+
+  if (query_filter_operator == FilterOperator::Or) {
+    return OrganizeFiltersForOr(filters, filter_index_pairs);
   }
 
-  std::vector<std::pair<CompositeIndex*, std::vector<FilterInfo>>> sorted_composite;
-  for (const auto& kv : usable_composite) {
-    sorted_composite.push_back(kv);
-  }
+  // ----- AND branch -----
+  std::map<CompositeIndex*, std::vector<FilterInfo>> prefix_filters_for_idx;
+  std::map<CompositeIndex*, std::vector<FilterInfo>> all_filters_for_idx;
+  BuildCompositeViews(filters, composite_indexes_,
+                      prefix_filters_for_idx, all_filters_for_idx);
+
+  std::map<CompositeIndex*, ChosenPlan> chosen;
+  ChoosePerCompositeStrategy(prefix_filters_for_idx, all_filters_for_idx,
+                             table_, chosen);
+
+  // Order: prefix strategies first, then SCANs. Within each group prefer
+  // composites covering more fields, so we don't double-scan the same field.
+  std::vector<std::pair<CompositeIndex*, ChosenPlan>> sorted_composite(
+      chosen.begin(), chosen.end());
   std::sort(sorted_composite.begin(), sorted_composite.end(),
       [](const auto& a, const auto& b) {
+        bool a_scan = a.second.strategy == CompositeStrategy::SCAN;
+        bool b_scan = b.second.strategy == CompositeStrategy::SCAN;
+        if (a_scan != b_scan) return !a_scan;  // prefix first
         return a.first->NumFields() > b.first->NumFields();
       });
 
   std::set<int> covered_fields;
-  bool has_composite_filter = false;
   for (const auto& kv : sorted_composite) {
     bool already_covered = true;
-    for (int fid : kv.first->GetFieldIds()) {
-      if (covered_fields.find(fid) == covered_fields.end()) {
+    for (const auto& f : kv.second.filters) {
+      if (covered_fields.find(f.field) == covered_fields.end()) {
         already_covered = false;
         break;
       }
     }
     if (already_covered) continue;
 
-    for (int fid : kv.first->GetFieldIds()) {
-      covered_fields.insert(fid);
-      composite_covered_fields.insert(fid);
+    for (const auto& f : kv.second.filters) {
+      covered_fields.insert(f.field);
     }
 
     FilterIndexPair pair;
     pair.composite_index = kv.first;
     pair.is_composite = true;
-    pair.filters = kv.second;
-    pair.strategy = strategies.at(kv.first);
+    pair.filters = kv.second.filters;
+    pair.strategy = kv.second.strategy;
+    pair.inner_op = FilterOperator::And;
     filter_index_pairs.push_back(std::move(pair));
-    has_composite_filter = true;
   }
+
   // Remaining filters not covered by any composite index: fall through to scalar index.
-  // Iterate directly over filters rather than field_ids to handle the case where
-  // the same field appears multiple times with different filter conditions.
   for (const auto& f : filters) {
-    if (composite_covered_fields.find(f.field) != composite_covered_fields.end()) continue;
+    if (covered_fields.find(f.field) != covered_fields.end()) continue;
     if (auto index = GetFieldIndex(f.field)) {
       FilterIndexPair pair;
       pair.index = index;
@@ -563,9 +695,6 @@ int ScalarIndexManager::OrganizeFiltersToIndex(
     }
   }
   if (filter_index_pairs.empty()) {
-    return -1;
-  }
-  if (has_composite_filter && query_filter_operator == FilterOperator::Or) {
     return -1;
   }
   std::set<int> can_execute_fields;
@@ -630,7 +759,14 @@ int64_t ScalarIndexManager::Search(
   for (const auto& filter_index_pair : filter_index_pairs) {
     ScalarIndexResult result_tmp;
     if (filter_index_pair.is_composite) {
-      CompositeFilter(filter_index_pair.composite_index, filter_index_pair.filters, filter_index_pair.strategy, result_tmp);
+      if (filter_index_pair.strategy == CompositeStrategy::SCAN) {
+        ExecuteScanCase(filter_index_pair.composite_index,
+                        filter_index_pair.filters,
+                        filter_index_pair.inner_op,
+                        result_tmp);
+      } else {
+        CompositeFilter(filter_index_pair.composite_index, filter_index_pair.filters, filter_index_pair.strategy, result_tmp);
+      }
     } else {
       Filter(filter_index_pair.index, filter_index_pair.filters[0], result_tmp);
     }
@@ -675,23 +811,26 @@ int64_t ScalarIndexManager::Query(
     }
   }
 
-  // Single field filter can return early if get enough result
+  // Single field filter can return early if get enough result.
+  // Only takes the fast path when a scalar index exists, or the field is the
+  // first column of a composite index (so a single prefix-seek is valid).
+  // Otherwise fall through to Search, which can use composite SCAN fallback.
   if (origin_filters.size() == 1) {
     const auto& filter = origin_filters[0];
     if (filter.lower_value.empty() && filter.upper_value.empty()) {
       return 0;
     }
-    ScalarIndexResult result;
-    auto index = GetFieldIndex(filter.field);
+    ScalarIndex* index = GetFieldIndex(filter.field);
     if (index == nullptr) {
       index = GetCompositeIndexByFieldId(filter.field, composite_indexes_);
-      if (index == nullptr) {
-        return 0;
-      }
     }
-    Filter(index, filter, result, offset, topn);
-    docids = result.GetDocIDs(topn);
-    return static_cast<int64_t>(docids.size());
+    if (index != nullptr) {
+      ScalarIndexResult result;
+      Filter(index, filter, result, offset, topn);
+      docids = result.GetDocIDs(topn);
+      return static_cast<int64_t>(docids.size());
+    }
+    // Fall through to Search; it can route the filter through composite SCAN.
   }
 
   ScalarIndexResults scalar_index_results;
@@ -855,6 +994,14 @@ void ScalarIndexManager::ExecuteInCase(
   }
 
   result = std::move(combined);
+}
+
+void ScalarIndexManager::ExecuteScanCase(
+    CompositeIndex* composite_idx,
+    const std::vector<FilterInfo>& match_filters,
+    FilterOperator inner_op,
+    ScalarIndexResult& result) {
+  result = composite_idx->Scan(match_filters, inner_op, 0, 0);
 }
 
 }  // namespace vearch

--- a/internal/engine/table/scalar_index_manager.h
+++ b/internal/engine/table/scalar_index_manager.h
@@ -24,56 +24,17 @@ namespace vearch {
 
 enum class ResultStatus : int64_t { ZERO = 0, INTERNAL_ERR = -1, KILLED = -2 };
 
-typedef struct {
-  int field;
-  std::string lower_value;
-  std::string upper_value;
-  bool include_lower;
-  bool include_upper;
-  FilterOperator is_union;
-
-  std::string ToString(enum DataType data_type) const {
-    std::stringstream ss;
-    ss << "field=" << field << ", include_lower=" << include_lower << ", include_upper=" << include_upper
-       << ", is_union=" << (is_union == FilterOperator::And ? "And" : is_union == FilterOperator::Or ? "Or" : "Not")
-       << ", data_type=" << DataTypeToString(data_type);
-    if (data_type == DataType::STRING || data_type == DataType::STRINGARRAY) {
-      ss << ", lower_value=" << lower_value << ", upper_value=" << upper_value;
-    } else if (data_type == DataType::INT) {
-      int lower_value_int;
-      memcpy(&lower_value_int, lower_value.c_str(), sizeof(int));
-      int upper_value_int;
-      memcpy(&upper_value_int, upper_value.c_str(), sizeof(int));
-      ss << ", lower_value=" << lower_value_int << ", upper_value=" << upper_value_int;
-    } else if (data_type == DataType::LONG || data_type == DataType::DATE) {
-      long lower_value_long;
-      memcpy(&lower_value_long, lower_value.c_str(), sizeof(long));
-      long upper_value_long;
-      memcpy(&upper_value_long, upper_value.c_str(), sizeof(long));
-      ss << ", lower_value=" << lower_value_long << ", upper_value=" << upper_value_long;
-    } else if (data_type == DataType::FLOAT) {
-      float lower_value_float;
-      memcpy(&lower_value_float, lower_value.c_str(), sizeof(float));
-      float upper_value_float;
-      memcpy(&upper_value_float, upper_value.c_str(), sizeof(float));
-      ss << ", lower_value=" << lower_value_float << ", upper_value=" << upper_value_float;
-    } else if (data_type == DataType::DOUBLE) {
-      double lower_value_double;
-      memcpy(&lower_value_double, lower_value.c_str(), sizeof(double));
-      double upper_value_double;
-      memcpy(&upper_value_double, upper_value.c_str(), sizeof(double));
-      ss << ", lower_value=" << lower_value_double << ", upper_value=" << upper_value_double;
-    }
-    return ss.str();
-  }
-} FilterInfo;
-
 struct FilterIndexPair {
   ScalarIndex* index;
   CompositeIndex* composite_index;
   std::vector<FilterInfo> filters;
   bool is_composite;
   CompositeStrategy strategy;
+  // For SCAN strategy only: how filters inside this bucket combine.
+  // AND -> entry must satisfy every filter to be emitted.
+  // OR  -> entry emitted if any filter matches.
+  // Ignored when strategy != SCAN.
+  FilterOperator inner_op = FilterOperator::And;
 };
 
 // ============================================================================
@@ -157,6 +118,12 @@ class ScalarIndexManager {
   // Check if a field belongs to any composite index and update them.
   int UpdateCompositeIndexes(int64_t docid, int field_id, bool is_add);
 
+  // OR-branch dispatch for OrganizeFiltersToIndex. Builds per-filter pairs:
+  // scalar where available, else SCAN-bucket on a composite that owns the
+  // field. Returns -1 when any field has no index that can serve it.
+  int OrganizeFiltersForOr(const std::vector<FilterInfo>& filters,
+                           std::vector<FilterIndexPair>& filter_index_pairs);
+
   /**
    * Execute EQUAL strategy: all composite fields have single-value filters (Eq mode).
    * Uses composite->Equal() for a single RocksDB seek.
@@ -194,6 +161,15 @@ class ScalarIndexManager {
   void ExecuteNotEqualCase(CompositeIndex* composite_idx,
                            const FilterInfo& filter,
                            ScalarIndexResult& result);
+
+  /**
+   * Execute SCAN strategy: full-iteration fallback when filters cannot form
+   * a valid composite key prefix. Delegates to CompositeIndex::Scan.
+   */
+  void ExecuteScanCase(CompositeIndex* composite_idx,
+                       const std::vector<FilterInfo>& match_filters,
+                       FilterOperator inner_op,
+                       ScalarIndexResult& result);
 
  public:
   Table *table_;

--- a/internal/engine/table/scalar_index_types.cc
+++ b/internal/engine/table/scalar_index_types.cc
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 The Gamma Authors.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+#include "scalar_index_types.h"
+
+#include <cstring>
+#include <sstream>
+
+#include "scalar_index_utils.h"
+
+namespace vearch {
+
+std::string ToString(FilterOperator filter_operator) {
+  switch (filter_operator) {
+    case FilterOperator::And:
+      return "And";
+    case FilterOperator::Or:
+      return "Or";
+    case FilterOperator::Not:
+      return "Not";
+    default:
+      return "Unknown";
+  }
+}
+
+std::string FilterInfo::ToString(enum DataType data_type) const {
+  std::stringstream ss;
+  ss << "field=" << field << ", include_lower=" << include_lower << ", include_upper=" << include_upper
+     << ", filter_operator=" << vearch::ToString(filter_operator)
+     << ", data_type=" << DataTypeToString(data_type);
+  if (data_type == DataType::STRING || data_type == DataType::STRINGARRAY) {
+    ss << ", lower_value=" << lower_value << ", upper_value=" << upper_value;
+  } else if (data_type == DataType::INT) {
+    int lower_value_int;
+    memcpy(&lower_value_int, lower_value.c_str(), sizeof(int));
+    int upper_value_int;
+    memcpy(&upper_value_int, upper_value.c_str(), sizeof(int));
+    ss << ", lower_value=" << lower_value_int << ", upper_value=" << upper_value_int;
+  } else if (data_type == DataType::LONG || data_type == DataType::DATE) {
+    long lower_value_long;
+    memcpy(&lower_value_long, lower_value.c_str(), sizeof(long));
+    long upper_value_long;
+    memcpy(&upper_value_long, upper_value.c_str(), sizeof(long));
+    ss << ", lower_value=" << lower_value_long << ", upper_value=" << upper_value_long;
+  } else if (data_type == DataType::FLOAT) {
+    float lower_value_float;
+    memcpy(&lower_value_float, lower_value.c_str(), sizeof(float));
+    float upper_value_float;
+    memcpy(&upper_value_float, upper_value.c_str(), sizeof(float));
+    ss << ", lower_value=" << lower_value_float << ", upper_value=" << upper_value_float;
+  } else if (data_type == DataType::DOUBLE) {
+    double lower_value_double;
+    memcpy(&lower_value_double, lower_value.c_str(), sizeof(double));
+    double upper_value_double;
+    memcpy(&upper_value_double, upper_value.c_str(), sizeof(double));
+    ss << ", lower_value=" << lower_value_double << ", upper_value=" << upper_value_double;
+  }
+  return ss.str();
+}
+
+}  // namespace vearch

--- a/internal/engine/table/scalar_index_types.h
+++ b/internal/engine/table/scalar_index_types.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 The Gamma Authors.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include "c_api/api_data/table.h"
+
+namespace vearch {
+
+/*
+  ScalarIndexType:
+    SCALAR: Base type (deprecated, treated as INVERTED for compatibility)
+    INVERTED:  RocksDB (field, value, docid) -> null   (one-to-one mapping)
+    INVERTED_LIST: (field, value) -> [docids] (one-to-many mapping) (future)
+    BITMAP: Roaring bitmap-based index
+    COMPOSITE: Composite index
+*/
+const std::string NULL_INDEX_TYPE_STRING = "NULL";
+const std::string SCALAR_INDEX_TYPE_STRING = "SCALAR";
+const std::string INVERTED_INDEX_TYPE_STRING = "INVERTED";
+const std::string INVERTED_LIST_INDEX_TYPE_STRING = "INVERTED_LIST";
+const std::string BITMAP_INDEX_TYPE_STRING = "BITMAP";
+const std::string COMPOSITE_INDEX_TYPE_STRING = "COMPOSITE";
+constexpr const char* kStringArrayValueDelimiter = "\001";
+
+enum class ScalarIndexType : uint8_t {
+  Null = 0,
+  Index = 1,
+  Scalar = 2,
+  Inverted = 3,
+  InvertedList = 4,
+  Bitmap = 5,
+  Composite = 6
+};
+
+enum class FilterOperator : uint8_t { And = 0, Or, Not };
+
+// Filter mode when matched against composite index prefix
+enum class CompositeFilterMode { Equal, NotEqual, In, NotIn, Range };
+
+// Composite filter execution strategies.
+// SCAN: full-iteration fallback when filters cannot form a valid composite
+// key prefix. Iterates every entry of the composite index and applies the
+// filters per entry.
+enum class CompositeStrategy { NONE, EQUAL, RANGE, IN, NOT_IN, NOT_EQUAL, SCAN };
+
+std::string ToString(FilterOperator filter_operator);
+
+typedef struct FilterInfo {
+  int field;
+  std::string lower_value;
+  std::string upper_value;
+  bool include_lower;
+  bool include_upper;
+  FilterOperator filter_operator;
+
+  std::string ToString(enum DataType data_type) const;
+} FilterInfo;
+
+}  // namespace vearch

--- a/internal/engine/table/scalar_index_utils.h
+++ b/internal/engine/table/scalar_index_utils.h
@@ -9,42 +9,9 @@
 
 #include <string>
 #include "c_api/api_data/table.h"
+#include "scalar_index_types.h"
 
 namespace vearch {
-
-/*
-  ScalarIndexType:
-    SCALAR: Base type (deprecated, treated as INVERTED for compatibility)
-    INVERTED:  RocksDB (field, value, docid) -> null   (one-to-one mapping)
-    INVERTED_LIST: (field, value) -> [docids] (one-to-many mapping) (future)
-    BITMAP: Roaring bitmap-based index
-    COMPOSITE: Composite index
-*/
-const std::string NULL_INDEX_TYPE_STRING = "NULL";
-const std::string SCALAR_INDEX_TYPE_STRING = "SCALAR";
-const std::string INVERTED_INDEX_TYPE_STRING = "INVERTED";
-const std::string INVERTED_LIST_INDEX_TYPE_STRING = "INVERTED_LIST";
-const std::string BITMAP_INDEX_TYPE_STRING = "BITMAP";
-const std::string COMPOSITE_INDEX_TYPE_STRING = "COMPOSITE";
-constexpr const char* kStringArrayValueDelimiter = "\001";
-
-enum class FilterOperator : uint8_t { And = 0, Or, Not };
-
-// Filter mode when matched against composite index prefix
-enum class CompositeFilterMode { Equal, NotEqual, In, NotIn, Range };
-
-// Composite filter execution strategies
-enum class CompositeStrategy { NONE, EQUAL, RANGE, IN, NOT_IN, NOT_EQUAL };
-
-enum class ScalarIndexType : uint8_t {
-  Null = 0,
-  Index = 1,
-  Scalar = 2,
-  Inverted = 3,
-  InvertedList = 4,
-  Bitmap = 5,
-  Composite = 6
-};
 
 std::string ScalarIndexTypeToString(enum ScalarIndexType scalar_index_type);
 

--- a/test/test_module_filter_composite_index.py
+++ b/test/test_module_filter_composite_index.py
@@ -557,7 +557,10 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(a_lo=lo, a_hi=hi, b_eq=b_val)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_prefix_eq_all_suffix(self):
         lo, hi = 30, 40
@@ -572,7 +575,10 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(a_lo=lo, a_hi=hi, b_eq=b_val, c_in=c_vals)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 # ----- Range on prefix field + Range on suffix field -----------------------------------------------
     """field_A >= lo AND field_A <= hi AND ((field_B >= v1 and field_B <= v1) OR field_C in [v2])"""
@@ -589,7 +595,10 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(a_lo=lo, a_hi=hi, b_lo=b_lo, b_hi=b_hi)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_prefix_range_suffix_no_match(self):
         lo, hi = 70, 80
@@ -621,7 +630,10 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(a_lo=lo, a_hi=hi, b_lo=b_lo, b_hi=b_hi, c_in=c_vals)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_prefix_range_all_suffix(self):
         lo, hi = 310, 350
@@ -637,7 +649,10 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(a_lo=lo, a_hi=hi, b_lo=b_lo, b_hi=b_hi, c_in=c_vals)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 # ----- Eq prefix + Range suffix (no suffix filter) --------------------------
     """field_A = v AND field_B IN [b_lo..b_hi]  (suffix empty after B, Range on B)"""
@@ -841,9 +856,12 @@ class TestIntIntString:
             ]},
             limit=TOTAL_DOCS
         )
-        assert len(docs) == 0
+        expected = _expected_docs(c_in=c_vals)
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
-    def test_in_suffix(self):
+    def test_in_suffix_no_match(self):
         """field_C IN with valid values"""
         c_vals = ["3", "5"]   # field_C do not hava
         docs = _query(
@@ -957,7 +975,9 @@ class TestIntIntString:
             limit=TOTAL_DOCS
         )
         expected = _expected_docs(a_eq=a_val, b_lo=b_lo, b_hi=b_hi, c_in=[c_val])
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_range_in_all_overlap_b_first(self):
         a_val = 50           # => b=500
@@ -973,9 +993,11 @@ class TestIntIntString:
             limit=TOTAL_DOCS
         )
         expected = _expected_docs(a_eq=a_val, b_lo=b_lo, b_hi=b_hi, c_in=[c_val])
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
-    def test_eq_range_in_all_overlap_b_first(self):
+    def test_eq_range_in_all_overlap_c_first(self):
         a_val = 50           # => b=500
         b_lo, b_hi = 400, 600   # 500 in range
         c_val = str(500 % NUM_C_VALUES)   # field_C for b=500
@@ -989,7 +1011,9 @@ class TestIntIntString:
             limit=TOTAL_DOCS
         )
         expected = _expected_docs(a_eq=a_val, b_lo=b_lo, b_hi=b_hi, c_in=[c_val])
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # ----- Empty result edge cases ---------------------------------------------
@@ -1124,7 +1148,9 @@ class TestStringIntFloat:
             {"field": "field_int", "operator": "=", "value": i_val}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if f_int[i] == i_val]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_all_three(self):
         vectors, f_str, f_int, f_float = _generate_s1_data()
@@ -1152,7 +1178,9 @@ class TestStringIntFloat:
             {"field": "field_float", "operator": "<=", "value": fl_hi}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if fl_lo <= f_float[i] <= fl_hi]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_str_range_int(self):
         """string = v AND int in range"""
@@ -1196,7 +1224,9 @@ class TestStringIntFloat:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_str[i] == "5" and fl_lo <= f_float[i] <= fl_hi]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # Schema 2: int + float + string  (string as suffix)
@@ -1344,7 +1374,9 @@ class TestIntFloatString:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_int[i] == 42 and f_str[i] in ["2", "12"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_int_in_str(self):
         """int range + IN on string suffix"""
@@ -1356,7 +1388,9 @@ class TestIntFloatString:
         expected = [i for i in range(TOTAL_DOCS)
                     if 100 <= f_int[i] <= 199 and f_str[i] in ["5", "9"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_float_in_str(self):
         vectors, f_int, f_float, f_str = _generate_s2_data()
@@ -1509,7 +1543,9 @@ class TestIntFloatStringArray:
             {"field": "field_float", "operator": "<=", "value": 99.9}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if 70.0 <= f_float[i] <= 99.9]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int_in_stra(self):
         vectors, f_int, f_float, f_stra = _generate_s3_data()
@@ -1520,7 +1556,9 @@ class TestIntFloatStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_int[i] == 300 and any(t in stra_vals for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int_eq_float_in_stra(self):
         vectors, f_int, f_float, f_stra = _generate_s3_data()
@@ -1543,7 +1581,9 @@ class TestIntFloatStringArray:
             {"field": "field_float", "operator": "<=", "value": fl_hi}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if fl_lo <= f_float[i] <= fl_hi]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # Schema 4: string_array + int + float  (string_array as prefix)
@@ -1680,7 +1720,9 @@ class TestStringArrayIntFloat:
         expected = [i for i in range(TOTAL_DOCS)
                     if any(t in ["5"] for t in f_stra[i]) and f_int[i] != int_val]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_stra_range_int(self):
         vectors, f_int, f_stra, f_float = _generate_s4_data()
@@ -1730,7 +1772,9 @@ class TestStringArrayIntFloat:
             {"field": "field_int", "operator": "=", "value": int_val}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if f_int[i] == int_val]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_int(self):
         vectors, f_int, f_stra, f_float = _generate_s4_data()
@@ -1740,7 +1784,9 @@ class TestStringArrayIntFloat:
             {"field": "field_int", "operator": "<=", "value": int_hi}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if int_lo <= f_int[i] <= int_hi]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_float(self):
         vectors, f_int, f_stra, f_float = _generate_s4_data()
@@ -1749,8 +1795,10 @@ class TestStringArrayIntFloat:
             {"field": "field_float", "operator": "=", "value": float_val}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if f_float[i] == float_val]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
-    
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
     def test_range_float(self):
         vectors, f_int, f_stra, f_float = _generate_s4_data()
         float_lo, float_hi = 55.0, 57.0
@@ -1759,7 +1807,9 @@ class TestStringArrayIntFloat:
             {"field": "field_float", "operator": "<=", "value": float_hi}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if float_lo <= f_float[i] <= float_hi]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # Schema 5: int + string + string_array  (string_array as suffix)
@@ -1880,7 +1930,7 @@ class TestIntStringStringArray:
             {"field": "field_int", "operator": "=", "value": 360},
             {"field": "field_str", "operator": "IN", "value": ["0"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if f_int[i] == 360 and any(t in ["0"] for t in f_str[i])]
+                    if f_int[i] == 360 and f_str[i] in ["0"]]
         logger.info(f"expected: {expected}")
         assert len(docs) == len(expected)
         doc_ids = sorted(int(d["_id"]) for d in docs)
@@ -1892,9 +1942,11 @@ class TestIntStringStringArray:
             {"field": "field_int", "operator": "!=", "value": 360},
             {"field": "field_str", "operator": "IN", "value": ["0"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if f_int[i] != 360 and any(t in ["0"] for t in f_str[i])]
+                    if f_int[i] != 360 and f_str[i] in ["0"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int_in_str(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -1902,7 +1954,7 @@ class TestIntStringStringArray:
             {"field": "field_int", "operator": "=", "value": 360},
             {"field": "field_str", "operator": "IN", "value": ["0"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if f_int[i] == 360 and any(t in ["0"] for t in f_str[i])]
+                    if f_int[i] == 360 and f_str[i] in ["0"]]
         logger.info(f"expected: {expected}")
         assert len(docs) == len(expected)
         doc_ids = sorted(int(d["_id"]) for d in docs)
@@ -1916,7 +1968,9 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_int[i] == 300 and any(t in ["0"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int_eq_str_eq_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -1941,7 +1995,9 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if 300 <= f_int[i] <= 302 and f_str[i] == "0" and any(t in ["0"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_int_eq_str_not_eq_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -1963,9 +2019,11 @@ class TestIntStringStringArray:
             {"field": "field_str", "operator": "IN", "value": ["0", "1"]},
             {"field": "field_stra", "operator": "IN", "value": ["0", "1"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if 300 <= f_int[i] <= 302 and any(t in ["0", "1"] for t in f_str[i]) and any(t in ["0", "1"] for t in f_stra[i])]
+                    if 300 <= f_int[i] <= 302 and f_str[i] in ["0", "1"] and any(t in ["0", "1"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int_in_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -1976,25 +2034,31 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_int[i] == 300 and any(t in stra_vals for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_str(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
         docs = _s5_query({"operator": "AND", "conditions": [
             {"field": "field_str", "operator": "IN", "value": ["0"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if any(t in ["0"] for t in f_str[i])]
+                    if f_str[i] in ["0"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_str(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
         docs = _s5_query({"operator": "AND", "conditions": [
             {"field": "field_str", "operator": "IN", "value": ["0", "1"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS)
-                    if any(t in ["0", "1"] for t in f_str[i])]
+                    if f_str[i] in ["0", "1"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -2003,7 +2067,9 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if any(t in ["0"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -2012,7 +2078,9 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if any(t in ["0", "1"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_str_eq_stra(self):
         vectors, f_int, f_str, f_stra = _generate_s5_data()
@@ -2022,11 +2090,13 @@ class TestIntStringStringArray:
         expected = [i for i in range(TOTAL_DOCS)
                     if f_str[i] == "0" and any(t in ["0"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # Schema 6: string + string_array + int  (int as suffix)
-_STR_STRA_INT_NAME = "composite_s6_space"
+_S6_NAME = "composite_s6_space"
 
 _cached_s6 = None
 
@@ -2056,11 +2126,11 @@ def _build_s6_space_config():
     indexes = [
         {"name": "idx_composite_s6",  "type": "COMPOSITE", "field_names": ["field_str", "field_stra", "field_int"]}
     ]
-    return {"name": _STR_STRA_INT_NAME, "partition_num": 1, "replica_num": 1, "fields": fields, "indexes": indexes}
+    return {"name": _S6_NAME, "partition_num": 1, "replica_num": 1, "fields": fields, "indexes": indexes}
 
 
 def _s6_query(filters, limit=10):
-    payload = {"db_name": db_name, "space_name": _STR_STRA_INT_NAME,
+    payload = {"db_name": db_name, "space_name": _S6_NAME,
                "filters": filters, "limit": limit}
     rs = requests.post(router_url + "/document/query",
                        auth=(username, password), json=payload)
@@ -2079,7 +2149,7 @@ def _s6_batch_upsert():
         if len(docs) >= 100 or i == TOTAL_DOCS - 1:
             url = router_url + "/document/upsert?timeout=120000"
             rs = requests.post(url, auth=(username, password),
-                              json={"db_name": db_name, "space_name": _STR_STRA_INT_NAME,
+                              json={"db_name": db_name, "space_name": _S6_NAME,
                                     "documents": docs})
             assert rs.json()["code"] == 0
             docs = []
@@ -2088,13 +2158,13 @@ def _s6_batch_upsert():
 @pytest.fixture(scope="module")
 def composite_s6_space():
     logger.info("Setting up schema-6 (string+string_array+int) test space...")
-    destroy(router_url, db_name, _STR_STRA_INT_NAME)
+    destroy(router_url, db_name, _S6_NAME)
     create_db(router_url, db_name)
     resp = create_space(router_url, db_name, _build_s6_space_config())
     assert resp.json()["code"] == 0
     _s6_batch_upsert()
     yield
-    destroy(router_url, db_name, _STR_STRA_INT_NAME)
+    destroy(router_url, db_name, _S6_NAME)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -2156,7 +2226,9 @@ class TestStringStringArrayInt:
             {"field": "field_stra", "operator": "NOT IN", "value": ["3"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if f_str[i] == "7" and "3" not in f_stra[i]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_on_str_in_stra(self):
         vectors, f_str, f_stra, f_int = _generate_s6_data()
@@ -2250,7 +2322,9 @@ class TestStringStringArrayInt:
             {"field": "field_stra", "operator": "IN", "value": ["3"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if any(t in ["3"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_on_stra(self):
         vectors, f_str, f_stra, f_int = _generate_s6_data()
@@ -2258,7 +2332,9 @@ class TestStringStringArrayInt:
             {"field": "field_stra", "operator": "IN", "value": ["3", "4"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if any(t in ["3", "4"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_stra_eq_int(self):
         vectors, f_str, f_stra, f_int = _generate_s6_data()
@@ -2279,11 +2355,13 @@ class TestStringStringArrayInt:
         expected = [i for i in range(TOTAL_DOCS)
                     if any(t in ["4", "5"] for t in f_stra[i]) and 6 <= f_int[i] <= 60]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
 
 # Schema 7: string + string_array + int  (int as suffix) with other scalar index
-_STR_STRA_INT_NAME = "composite_s7_space"
+_S7_NAME = "composite_s7_space"
 
 _cached_s7 = None
 
@@ -2313,10 +2391,10 @@ def _build_s7_space_config():
     indexes = [
         {"name": "idx_composite_s7",  "type": "COMPOSITE", "field_names": ["field_str", "field_stra", "field_int"]}
     ]
-    return {"name": _STR_STRA_INT_NAME, "partition_num": 1, "replica_num": 1, "fields": fields, "indexes": indexes}
+    return {"name": _S7_NAME, "partition_num": 1, "replica_num": 1, "fields": fields, "indexes": indexes}
 
 def _s7_query(filters, limit=10):
-    payload = {"db_name": db_name, "space_name": _STR_STRA_INT_NAME,
+    payload = {"db_name": db_name, "space_name": _S7_NAME,
                "filters": filters, "limit": limit}
     rs = requests.post(router_url + "/document/query",
                        auth=(username, password), json=payload)
@@ -2326,7 +2404,7 @@ def _s7_query(filters, limit=10):
 
 
 def _s7_batch_upsert():
-    vectors, f_str, f_stra, f_int = _generate_s6_data()
+    vectors, f_str, f_stra, f_int = _generate_s7_data()
     docs = []
     for i in range(TOTAL_DOCS):
         docs.append({"_id": str(i), "field_str": str(f_str[i]),
@@ -2335,7 +2413,7 @@ def _s7_batch_upsert():
         if len(docs) >= 100 or i == TOTAL_DOCS - 1:
             url = router_url + "/document/upsert?timeout=120000"
             rs = requests.post(url, auth=(username, password),
-                              json={"db_name": db_name, "space_name": _STR_STRA_INT_NAME,
+                              json={"db_name": db_name, "space_name": _S7_NAME,
                                     "documents": docs})
             assert rs.json()["code"] == 0
             docs = []
@@ -2344,13 +2422,13 @@ def _s7_batch_upsert():
 @pytest.fixture(scope="module")
 def composite_s7_space():
     logger.info("Setting up schema-7 (string+string_array+int) test space...")
-    destroy(router_url, db_name, _STR_STRA_INT_NAME)
+    destroy(router_url, db_name, _S7_NAME)
     create_db(router_url, db_name)
     resp = create_space(router_url, db_name, _build_s7_space_config())
     assert resp.json()["code"] == 0
     _s7_batch_upsert()
     yield
-    destroy(router_url, db_name, _STR_STRA_INT_NAME)
+    destroy(router_url, db_name, _S7_NAME)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -2412,7 +2490,9 @@ class TestStringStringArrayIntWithOtherScalarIndex:
             {"field": "field_stra", "operator": "NOT IN", "value": ["3"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if f_str[i] == "7" and "3" not in f_stra[i]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_on_str_in_stra(self):
         vectors, f_str, f_stra, f_int = _generate_s7_data()
@@ -2506,7 +2586,9 @@ class TestStringStringArrayIntWithOtherScalarIndex:
             {"field": "field_stra", "operator": "IN", "value": ["3"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if any(t in ["3"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_on_stra(self):
         vectors, f_str, f_stra, f_int = _generate_s7_data()
@@ -2514,7 +2596,9 @@ class TestStringStringArrayIntWithOtherScalarIndex:
             {"field": "field_stra", "operator": "IN", "value": ["3", "4"]}]}, limit=TOTAL_DOCS)
         expected = [i for i in range(TOTAL_DOCS) if any(t in ["3", "4"] for t in f_stra[i])]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_in_stra_eq_int(self):
         vectors, f_str, f_stra, f_int = _generate_s7_data()
@@ -2535,7 +2619,9 @@ class TestStringStringArrayIntWithOtherScalarIndex:
         expected = [i for i in range(TOTAL_DOCS)
                     if any(t in ["4", "5"] for t in f_stra[i]) and 6 <= f_int[i] <= 60]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_eq_int(self):
         vectors, f_str, f_stra, f_int = _generate_s7_data()
@@ -2713,6 +2799,25 @@ class TestMultiCompositeIndexes:
         doc_ids = sorted(int(d["_id"]) for d in docs)
         assert doc_ids == expected
 
+    def test_eq_A_C(self):
+        """Query A AND C: [A,B] for A (prefix EQUAL), [B,C] for C (SCAN fallback).
+
+        Before SCAN fallback this returned 0 because A could only be served
+        by [A,B] and C only by [B,C] but neither could form a usable prefix
+        for the single field present, so the planner gave up. With SCAN
+        the [B,C] index can iterate and filter C; [A,B] handles A.
+        """
+        vectors, f_a, f_b, f_c, f_d = _generate_s8_data()
+        docs = _s8_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 300},
+            {"field": "field_C", "operator": "IN", "value": ["0"]}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_a[i] == 300 and f_c[i] == "0"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
     def test_eq_A_B_C(self):
         """Query A AND B AND C: merge [A,B] + [B,C] -> both execute, intersection gives result.
 
@@ -2767,7 +2872,9 @@ class TestMultiCompositeIndexes:
         assert doc_ids == expected
 
     def test_range_A_B(self):
-        """Query range on A and B: [A,B] composite handles Range on both fields."""
+        """Range on A and Range on B: composites need SCAN since same field
+        repeats (lower + upper as two filters). Both [A,B] and [B,C] are
+        valid SCAN candidates; their intersection gives the result."""
         vectors, f_a, f_b, f_c, f_d = _generate_s8_data()
         docs = _s8_query({"operator": "AND", "conditions": [
             {"field": "field_A", "operator": ">=", "value": 100},
@@ -2777,10 +2884,14 @@ class TestMultiCompositeIndexes:
         expected = [i for i in range(TOTAL_DOCS)
                     if 100 <= f_a[i] <= 105 and 1000 <= f_b[i] <= 1050]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
 
     def test_range_A_in_B_C(self):
-        """Query range on A, IN on B and C: [A,B] + [B,C] both execute, intersection."""
+        """Range on A, Equal on B, IN on C: [A,B] has duplicate-field A so
+        only SCAN works; [B,C] still uses prefix IN. Together they fully
+        cover A/B/C."""
         vectors, f_a, f_b, f_c, f_d = _generate_s8_data()
         docs = _s8_query({"operator": "AND", "conditions": [
             {"field": "field_A", "operator": ">=", "value": 50},
@@ -2792,4 +2903,595 @@ class TestMultiCompositeIndexes:
                     and f_b[i] == 500
                     and f_c[i] in ["5", "10"]]
         logger.info(f"expected: {expected}")
-        assert len(docs) == 0
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+
+# Schema 9: composite [A,B,C] with scalar indexes on B and C.
+# Tests: ABC uses composite, AC/BC/B/C fall through to scalar indexes.
+_S9_SPACE_NAME = "composite_s9_space"
+_cached_s9 = None
+
+
+def _generate_s9_data():
+    global _cached_s9
+    if _cached_s9 is not None:
+        return _cached_s9
+    rng = np.random.default_rng(seed=99)
+    vectors = rng.random((TOTAL_DOCS, EMBEDDING_DIM), dtype=np.float32)
+    f_a = np.arange(TOTAL_DOCS, dtype=np.int32)
+    f_b = (f_a * 10).astype(np.int32)
+    f_c = np.array([str(x) for x in f_a], dtype=object)
+    _cached_s9 = (vectors, f_a, f_b, f_c)
+    return _cached_s9
+
+
+def _build_s9_space_config():
+    fields = [
+        {"name": "field_A", "type": "integer"},
+        {"name": "field_B", "type": "integer", "index": {"name": "idx_B", "type": "SCALAR"}},
+        {"name": "field_C", "type": "string", "index": {"name": "idx_C", "type": "SCALAR"}},
+        {"name": "field_vector", "type": "vector",
+         "dimension": EMBEDDING_DIM, "store_type": "MemoryOnly",
+         "index": {"name": "gamma", "type": "FLAT", "params": {"metric_type": "L2"}}},
+    ]
+    indexes = [
+        {"name": "idx_composite_ABC", "type": "COMPOSITE",
+         "field_names": ["field_A", "field_B", "field_C"]},
+    ]
+    return {
+        "name": _S9_SPACE_NAME,
+        "partition_num": 1,
+        "replica_num": 1,
+        "fields": fields,
+        "indexes": indexes,
+    }
+
+
+def _s9_query(filters, limit=10):
+    payload = {"db_name": db_name, "space_name": _S9_SPACE_NAME,
+               "filters": filters, "limit": limit}
+    rs = requests.post(router_url + "/document/query",
+                       auth=(username, password), json=payload)
+    assert rs.status_code == 200, f"s9 query failed: {rs.text}"
+    assert rs.json()["code"] == 0, f"s9 query code != 0: {rs.json()}"
+    return rs.json()["data"]["documents"]
+
+
+def _s9_batch_upsert():
+    vectors, f_a, f_b, f_c = _generate_s9_data()
+    docs = []
+    for i in range(TOTAL_DOCS):
+        docs.append({
+            "_id": str(i),
+            "field_A": int(f_a[i]),
+            "field_B": int(f_b[i]),
+            "field_C": str(f_c[i]),
+            "field_vector": vectors[i].tolist(),
+        })
+        if len(docs) >= 100 or i == TOTAL_DOCS - 1:
+            url = router_url + "/document/upsert?timeout=120000"
+            rs = requests.post(url, auth=(username, password),
+                              json={"db_name": db_name, "space_name": _S9_SPACE_NAME,
+                                    "documents": docs})
+            assert rs.json()["code"] == 0
+            docs = []
+
+
+@pytest.fixture(scope="module")
+def composite_s9_space():
+    logger.info("Setting up schema-9 (composite [A,B,C] + scalar on B and C) test space...")
+    destroy(router_url, db_name, _S9_SPACE_NAME)
+    create_db(router_url, db_name)
+    resp = create_space(router_url, db_name, _build_s9_space_config())
+    assert resp.json()["code"] == 0, f"create_space s9 failed: {resp.json()}"
+    _s9_batch_upsert()
+    yield
+    destroy(router_url, db_name, _S9_SPACE_NAME)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _request_s9(composite_s9_space):
+    pass
+
+
+class TestCompositeWithScalarOverlap:
+    """Schema: [A:int, B:int, C:string] with composite [A,B,C] and scalar [B], [C].
+
+    Composite [A,B,C] requires all three fields in order to be usable.
+    Queries that don't provide all three (or a valid prefix) fall back to scalar indexes.
+
+    Test matrix:
+      - ABC: composite [A,B,C] (all 3 fields present)
+      - AC:  composite [A,B,C] for A (partial prefix usage) + scalar [C] for C 
+      - BC:  scalar [B] + scalar [C] (A is missing at start -> composite unusable)
+      - B:   scalar [B]
+      - C:   scalar [C]
+    """
+
+    def test_eq_A_B_C(self):
+        """Query A AND B AND C: composite [A,B,C] handles all three fields."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 100},
+            {"field": "field_B", "operator": "=", "value": 1000},
+            {"field": "field_C", "operator": "IN", "value": ["100"]}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_a[i] == 100 and f_b[i] == 1000 and f_c[i] == "100"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_eq_A_C(self):
+        """Query A AND C: composite [A,B,C] for A (partial prefix), scalar [C] for C.
+        The composite index contributes only the A filter (first field of its prefix);
+        C is not covered by the composite so it falls back to the scalar index."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 200},
+            {"field": "field_C", "operator": "IN", "value": ["200"]}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_a[i] == 200 and f_c[i] == "200"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_eq_B_C(self):
+        """Query B AND C: A is missing (required at start of composite), composite skipped.
+        Falls back to scalar [B] AND scalar [C]."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": "=", "value": 500},
+            {"field": "field_C", "operator": "IN", "value": ["50"]}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_b[i] == 500 and f_c[i] == "50"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_eq_C_B(self):
+        """Query B AND C: A is missing (required at start of composite), composite skipped.
+        Falls back to scalar [B] AND scalar [C]."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_C", "operator": "IN", "value": ["50"]},
+            {"field": "field_B", "operator": "=", "value": 500}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_c[i] == "50" and f_b[i] == 500]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_eq_B(self):
+        """Query B alone: scalar [B] used."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": "=", "value": 500}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if f_b[i] == 500]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_eq_C(self):
+        """Query C alone: scalar [C] used."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_C", "operator": "IN", "value": ["50"]}]}, limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if f_c[i] == "50"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+
+class TestCompositeOrSemantics:
+    """Schema-9 OR queries against composite [A,B,C] with scalar on B and C.
+
+    These tests assert the *correct* OR semantics. With the current code
+    (scalar_index_manager.cc has_composite_filter && Or -> return -1),
+    OR queries touching any composite field return empty for pure
+    /document/query and lose filtering for vector search. After SCAN
+    fallback is implemented, these should pass.
+
+    Each test logs the expected docid set so the failure message tells
+    you exactly what's missing.
+    """
+
+    def test_or_A_B(self):
+        """A=100 OR B=5000. A has only composite; B has scalar.
+        Expected union: docids where f_a==100 or f_b==5000."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 100},
+            {"field": "field_B", "operator": "=", "value": 5000}]}, limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == 100 or f_b[i] == 5000})
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_or_A_C(self):
+        """A=200 OR C IN ['200']. A only in composite; C has scalar.
+        With Bug 2 the response is currently empty."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 200},
+            {"field": "field_C", "operator": "IN", "value": ["200"]}]}, limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == 200 or f_c[i] == "200"})
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_or_B_C(self):
+        """B=500 OR C IN ['50']. Neither references A, so composite is
+        skipped from candidate selection. Currently passes because no
+        composite filter is produced; included as a control."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_B", "operator": "=", "value": 500},
+            {"field": "field_C", "operator": "IN", "value": ["50"]}]}, limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_b[i] == 500 or f_c[i] == "50"})
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_or_A_only_two_vals(self):
+        """A=100 OR A=200. Both filters target the same composite-only
+        field; CanUseCompositeFilter rejects duplicates (line 449),
+        and A has no scalar fallback. Currently empty."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 100},
+            {"field": "field_A", "operator": "=", "value": 200}]}, limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == 100 or f_a[i] == 200})
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_or_A_B_C(self):
+        """A=100 OR B=2000 OR C IN ['300']. Mixed composite-only + scalar
+        fields under OR; currently returns empty."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 100},
+            {"field": "field_B", "operator": "=", "value": 2000},
+            {"field": "field_C", "operator": "IN", "value": ["300"]}]}, limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == 100 or f_b[i] == 2000 or f_c[i] == "300"})
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    def test_or_A_range(self):
+        """A>=100 AND A<=102 expressed as range -- single filter, but A
+        only sits in composite. Sanity check that single-filter OR-equiv
+        path also works. Currently the single-filter shortcut in
+        ScalarIndexManager::Query bypasses OrganizeFiltersToIndex
+        (line 674) so this may actually pass today; control case."""
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": ">=", "value": 100},
+            {"field": "field_A", "operator": "<=", "value": 102}]}, limit=TOTAL_DOCS)
+        # OR semantics: A>=100 OR A<=102 covers ALL docs (since every int
+        # satisfies one side); this primarily tests that the path doesn't
+        # crash or silently return empty.
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] >= 100 or f_a[i] <= 102})
+        logger.info(f"expected count: {len(expected)}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+
+
+class TestCompositeScanRegressions:
+    """Targeted regression tests for the composite SCAN fallback.
+
+    These exercise paths that the existing schema-specific tests don't
+    cover cleanly:
+      * STRINGARRAY NOT IN aggregation (per-docid value set, not per-key)
+      * Single-filter non-prefix query routed through Query -> Search
+      * AND with composite SCAN combined with a scalar index hit
+      * SCAN with offset/limit truncation
+      * Range with exclusive bounds (>, <)
+      * OR SCAN with NOT IN on a composite-only field
+      * Same field appearing in >=3 OR filters
+      * Filter that matches zero documents
+    """
+
+    # ---- 1. STRINGARRAY NOT IN aggregation regression -------------------
+    # Schema 5: [int, str, stra]; f_stra[i] = [str(i%6), str((i+1)%6)].
+    # A doc with stra containing "0" must be excluded by NOT IN ["0"],
+    # regardless of whether the array also contains other values that
+    # individually wouldn't match. Pre-fix, the "1"/"5" key entry for a
+    # doc with stra=["0","1"] would slip through.
+    def test_stringarray_not_in_excludes_all_occurrences(self):
+        vectors, f_int, f_str, f_stra = _generate_s5_data()
+        docs = _s5_query({"operator": "AND", "conditions": [
+            {"field": "field_stra", "operator": "NOT IN", "value": ["0"]}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if "0" not in f_stra[i]]
+        logger.info(f"expected count: {len(expected)}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 2. Single-filter non-prefix field via Query fast-path fallback --
+    # Pre-fix, Query's single-filter fast path returned 0 whenever the
+    # field had no scalar index and was not the first column of a
+    # composite. After the fix it falls through to Search/SCAN. Test the
+    # two paths separately:
+    #   (a) NotEqual on A: A is first column, fast path takes it
+    #       directly via CompositeIndex's inherited NotEqual.
+    #   (b) Eq on B: B is middle of composite [A,B,C] and also has a
+    #       scalar index, so the fast path resolves via scalar. This
+    #       confirms the rebuilt branching still picks an index.
+    def test_single_not_equal_composite_only_field(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "!=", "value": 100}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if f_a[i] != 100]
+        logger.info(f"expected count: {len(expected)}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # B is middle field of composite [A,B,C]; using only B forces SCAN
+    # because B alone is not a valid prefix. B also has a scalar index,
+    # so the planner could pick either. Asserting correctness regardless.
+    def test_single_filter_middle_field(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": "=", "value": 5000}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if f_b[i] == 5000]
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # Single filter on a non-prefix composite-only field. Schema 5
+    # composite is [field_int, field_str, field_stra] with NO scalar
+    # indexes. A single filter on field_str hits the exact path that was
+    # previously returning 0: GetFieldIndex returns null, the composite
+    # exists but field_str is not its first column so
+    # GetCompositeIndexByFieldId also returns null. The fix falls through
+    # to Search, which routes via composite SCAN.
+    def test_single_filter_non_prefix_composite_only(self):
+        vectors, f_int, f_str, f_stra = _generate_s5_data()
+        docs = _s5_query({"operator": "AND", "conditions": [
+            {"field": "field_str", "operator": "IN", "value": ["3"]}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS) if f_str[i] == "3"]
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 3. AND: composite SCAN + scalar index in same query -----------
+    # A only in composite; C has scalar index. A=x AND C=y forces A
+    # through composite SCAN and C through scalar. Verify Intersection
+    # combines them.
+    def test_and_composite_scan_with_scalar(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 250},
+            {"field": "field_C", "operator": "IN", "value": ["250"]}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_a[i] == 250 and f_c[i] == "250"]
+        logger.info(f"expected: {expected}")
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 4. SCAN with limit truncation ---------------------------------
+    # field_B alone forces SCAN on [A,B,C] composite. Range matches many
+    # docs; limit clamps the response. Verify count == limit and ids are
+    # a subset of the expected set.
+    def test_scan_limit_truncates(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        limit = 5
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": ">=", "value": 0},
+            {"field": "field_B", "operator": "<=", "value": 1000}]},
+            limit=limit)
+        expected_set = {i for i in range(TOTAL_DOCS) if 0 <= f_b[i] <= 1000}
+        assert len(docs) <= limit
+        doc_ids = {int(d["_id"]) for d in docs}
+        assert doc_ids.issubset(expected_set)
+
+    # ---- 5. Range with exclusive bounds via SCAN -----------------------
+    # B is middle field; > and < force SCAN. Verify AdjustDataTypeBoundary
+    # produces the exclusive bound correctly through the SCAN path.
+    def test_scan_range_exclusive_bounds(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": ">", "value": 1000},
+            {"field": "field_B", "operator": "<", "value": 1050}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_b[i] > 1000 and f_b[i] < 1050]
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # Boundary case: exclusive bounds where raw data values fall on the
+    # adjusted bound (lower+1, upper-1). f_b is step-10, so `> 999`
+    # adjusts the lower bound to 1000 and raw=1000 exists. A double
+    # adjustment in PrepareFilters would drop f_b == 1000.
+    def test_scan_range_exclusive_boundary_value(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": ">", "value": 999},
+            {"field": "field_B", "operator": "<=", "value": 1010}]},
+            limit=TOTAL_DOCS)
+        expected = [i for i in range(TOTAL_DOCS)
+                    if f_b[i] > 999 and f_b[i] <= 1010]
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 6. OR SCAN with NOT IN on composite-only string field ---------
+    # Use schema 7 (StringStringArrayIntWithOtherScalarIndex). Composite
+    # is [field_str, field_stra, field_int]; field_int additionally has a
+    # scalar index. NOT IN on field_str (composite-only at the prefix
+    # position, but combined with OR forces SCAN bucketing) OR'd with a
+    # scalar-backed equality on field_int.
+    def test_or_not_in_composite_string_with_scalar(self):
+        vectors, f_str, f_stra, f_int = _generate_s7_data()
+        docs = _s7_query({"operator": "OR", "conditions": [
+            {"field": "field_str", "operator": "NOT IN", "value": ["0"]},
+            {"field": "field_int", "operator": "=", "value": 100}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_str[i] not in ["0"] or f_int[i] == 100})
+        logger.info(f"expected count: {len(expected)}")
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 7. Three OR filters on the same field via composite SCAN ------
+    # A has no scalar index; three Eq filters on A are bucketed into one
+    # SCAN with inner_op=Or. Verify all three values are reachable.
+    def test_or_three_values_same_composite_field(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "OR", "conditions": [
+            {"field": "field_A", "operator": "=", "value": 100},
+            {"field": "field_A", "operator": "=", "value": 200},
+            {"field": "field_A", "operator": "=", "value": 300}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] in (100, 200, 300)})
+        assert len(docs) == len(expected)
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 8. SCAN that matches zero documents ---------------------------
+    # B has values 0..9990 step 10. Range entirely outside that produces
+    # an empty result via SCAN; verify no crash and empty response.
+    def test_scan_empty_result(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_B", "operator": ">=", "value": 10_000_000},
+            {"field": "field_B", "operator": "<=", "value": 10_000_100}]},
+            limit=TOTAL_DOCS)
+        assert docs == []
+
+    # ---- 9. AND SCAN with Equal-prefix on A + NotEqual on B ------------
+    # Exercises the seek-prefix optimization: A = single value pins the
+    # leading composite column, while B != v cannot contribute to the
+    # prefix (Not predicates break the prefix chain). The iterator should
+    # seek directly to the A=v segment and stop when the prefix no longer
+    # matches, applying the NotEqual filter to B inline. NOT IN is not
+    # supported on numeric fields at the API layer, so NotEqual is the
+    # right surrogate for "negative numeric filter past the prefix".
+    def test_scan_eq_prefix_a_with_not_eq_b(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        a_val = 250
+        b_excluded = int(f_b[a_val])  # one specific B value to exclude
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": a_val},
+            {"field": "field_B", "operator": "!=", "value": b_excluded}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == a_val and int(f_b[i]) != b_excluded})
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 10. AND SCAN: Equal A + Range B (numeric range sub-scan) ------
+    # A pins the leading column; B has a numeric Range. The optimizer
+    # should produce a single segment seeking to A=v|B>=lo and
+    # short-circuit the segment when the iterator advances past B>hi.
+    # We can only assert correctness from the API surface, not the
+    # internal scanned counter, so we verify result equivalence.
+    def test_scan_eq_prefix_a_range_b(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        a_val = 300
+        b_lo, b_hi = 1000, 5000
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": a_val},
+            {"field": "field_B", "operator": ">=", "value": b_lo},
+            {"field": "field_B", "operator": "<=", "value": b_hi}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == a_val
+                           and b_lo <= f_b[i] <= b_hi})
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 11. AND SCAN: STRINGARRAY at prefix position, single-value IN -
+    # Composite s4 is [field_stra, field_int, field_float]. The leading
+    # STRINGARRAY column is now allowed into the seek prefix when the
+    # filter is positive single-value (IN with one item) AND that field
+    # has no other filter in the query. Pair it with a Range on field_int
+    # to also exercise the per-entry suffix evaluation.
+    def test_scan_stra_prefix_single_value_in(self):
+        vectors, f_int, f_stra, f_float = _generate_s4_data()
+        stra_target = "3"
+        int_lo, int_hi = 100, 400
+        docs = _s4_query({"operator": "AND", "conditions": [
+            {"field": "field_stra", "operator": "IN", "value": [stra_target]},
+            {"field": "field_int", "operator": ">=", "value": int_lo},
+            {"field": "field_int", "operator": "<=", "value": int_hi}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if stra_target in f_stra[i]
+                           and int_lo <= int(f_int[i]) <= int_hi})
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 12. AND SCAN: STRINGARRAY at prefix position, IN + NOT IN -----
+    # Regression: when the leading STRINGARRAY field has BOTH a positive
+    # IN filter and a NOT IN filter in the same query, the prefix
+    # optimizer must NOT cut the iteration to the IN segment, because the
+    # per-docid aggregated view of array values would then miss elements
+    # that live in other segments and the NOT IN judgement would flip
+    # incorrectly. Verify the result matches brute-force expectation.
+    def test_scan_stra_in_and_not_in_same_field(self):
+        vectors, f_int, f_stra, f_float = _generate_s4_data()
+        included = "3"
+        excluded = "5"
+        docs = _s4_query({"operator": "AND", "conditions": [
+            {"field": "field_stra", "operator": "IN", "value": [included]},
+            {"field": "field_stra", "operator": "NOT IN", "value": [excluded]}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if included in f_stra[i]
+                           and excluded not in f_stra[i]})
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected
+
+    # ---- 13. AND SCAN: Equal A + IN C (string IN multi-segment) --------
+    # Same shape as the numeric IN test but on the trailing string column,
+    # so the multi-segment expansion has to encode each item via the
+    # sortable length-prefixed string format.
+    def test_scan_eq_prefix_a_in_c_strings(self):
+        vectors, f_a, f_b, f_c = _generate_s9_data()
+        a_val = 500
+        c_vals = [f_c[i] for i in range(TOTAL_DOCS)
+                  if f_a[i] == a_val][:1]
+        c_vals = list({*c_vals, f_c[a_val + 1], f_c[a_val + 2]})
+        docs = _s9_query({"operator": "AND", "conditions": [
+            {"field": "field_A", "operator": "=", "value": a_val},
+            {"field": "field_C", "operator": "IN", "value": c_vals}]},
+            limit=TOTAL_DOCS)
+        expected = sorted({i for i in range(TOTAL_DOCS)
+                           if f_a[i] == a_val and f_c[i] in c_vals})
+        assert len(docs) == len(expected), f"got {len(docs)}, expected {len(expected)}"
+        doc_ids = sorted(int(d["_id"]) for d in docs)
+        assert doc_ids == expected


### PR DESCRIPTION
Adds a full-iteration SCAN strategy that the composite scalar index can fall back to when the query filter set cannot form a valid key prefix. Iterates every entry under the composite header, decodes each field value from the key, and applies the filters per entry.

To avoid actually scanning the whole header when partial information is usable, the scan narrows itself opportunistically:
  - leading-Equal seek prefix: consecutive AND filters that pin a single value (numeric Equal, string IN with one item, single positive single-value STRINGARRAY filter) become a Seek prefix
  - string IN with up to 16 values: expanded into per-value sub-scans
  - numeric Range: single sub-scan starting at the encoded lower bound with upper-bound short-circuit during iteration
  - everything else falls back to scanning under the equal_prefix (or the bare header if no leading Equal exists)

STRINGARRAY presence forces a per-docid aggregation pass so that NOT IN / IN against array fields see the full element set rather than evaluating each cartesian-expanded entry independently.

Other pieces folded into this change:
  - route single-filter composite SCAN through the existing Search dispatch
  - split shared scalar-index types into scalar_index_types.h to break an include cycle around FilterInfo
  - regression test coverage in test_module_filter_composite_index.py