### PR TITLE
perf(vector index): reduce is_killed() checks on search hot path...

### DIFF
--- a/internal/engine/c_api/api_data/request_context.h
+++ b/internal/engine/c_api/api_data/request_context.h
@@ -83,6 +83,19 @@ class RequestContext {
   static void set_kill_status(std::string request_id, int partition_id, int reason);
   static bool is_killed(std::string request_id, int partition_id);
   static bool is_killed();
+
+  // Amortized kill-check for hot scan loops: only calls the (relatively
+  // expensive) is_killed() once every `Stride` iterations. `i` is the loop
+  // counter, so i == 0 (each list's first iteration) always checks. Stride is
+  // a template parameter forced to a power of two, so the mask trick can never
+  // be misconfigured to a non-power-of-two period.
+  template <size_t Stride>
+  static bool is_killed_every(size_t i) {
+    static_assert((Stride & (Stride - 1)) == 0,
+                  "Stride must be a power of two");
+    return (i & (Stride - 1)) == 0 && is_killed();
+  }
+
   static void delete_kill_status(std::string request_id, int partition_id);
 
 };

--- a/internal/engine/index/impl/gamma_index_binary_ivf.cc
+++ b/internal/engine/index/impl/gamma_index_binary_ivf.cc
@@ -318,11 +318,11 @@ int GammaIndexBinaryIVF::Search(RetrievalContext *retrieval_context, int n,
   int32_t dists[n * k];
   search_preassigned(retrieval_context, n, x, k, idx.get(), coarse_dis.get(),
                      dists, ids, nprobe, false);
+  if (RequestContext::is_killed()) {
+    return -2;
+  }
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < k; j++) {
-      if (RequestContext::is_killed()) {
-        return -2;
-      }
       distances[i * k + j] = dists[i * k + j];
     }
   }
@@ -448,7 +448,7 @@ struct GammaIVFBinaryScannerL2 : GammaBinaryInvertedListScanner {
 
     size_t nup = 0;
     for (size_t j = 0; j < n; j++, codes += code_size) {
-      if (RequestContext::is_killed()) break;
+      if (RequestContext::is_killed_every<1024>(j)) break;
       idx_t id = store_pairs ? (list_no << 32 | j) : ids[j];
       if (retrieval_context_->IsValid(id) == false) {
         continue;

--- a/internal/engine/index/impl/gamma_index_ivfflat.cc
+++ b/internal/engine/index/impl/gamma_index_ivfflat.cc
@@ -760,21 +760,17 @@ void GammaIVFFlatIndex::search_preassigned(RetrievalContext *retrieval_context,
 #pragma omp barrier
 #pragma omp critical
         {
-          if (!RequestContext::is_killed()) {
-            if (metric_type == METRIC_INNER_PRODUCT) {
-              heap_addn<HeapForIP>(k, simi, idxi, local_dis.data(),
-                                   local_idx.data(), k);
-            } else {
-              heap_addn<HeapForL2>(k, simi, idxi, local_dis.data(),
-                                   local_idx.data(), k);
-            }
+          if (metric_type == METRIC_INNER_PRODUCT) {
+            heap_addn<HeapForIP>(k, simi, idxi, local_dis.data(),
+                                 local_idx.data(), k);
+          } else {
+            heap_addn<HeapForL2>(k, simi, idxi, local_dis.data(),
+                                 local_idx.data(), k);
           }
         }
 #pragma omp barrier
 #pragma omp single
-        if (!RequestContext::is_killed()) {
-          reorder_result(simi, idxi);
-        }
+        reorder_result(simi, idxi);
       }
     } else {
       FAISS_THROW_FMT("parallel_mode %d not supported\n", pmode);

--- a/internal/engine/index/impl/gamma_index_ivfflat.h
+++ b/internal/engine/index/impl/gamma_index_ivfflat.h
@@ -65,7 +65,7 @@ struct GammaIVFFlatScanner : faiss::InvertedListScanner {
     const float *list_vecs = (const float *)codes;
     size_t nup = 0;
     for (size_t j = 0; j < list_size; j++) {
-      if (RequestContext::is_killed()) {
+      if (RequestContext::is_killed_every<512>(j)) {
         break;
       }
 

--- a/internal/engine/index/impl/gamma_index_ivfpq.cc
+++ b/internal/engine/index/impl/gamma_index_ivfpq.cc
@@ -686,7 +686,7 @@ void compute_dis(int k, const float *xi, float *simi, idx_t *idxi,
     }
     int raw_d = vec->MetaInfo()->Dimension();
     for (int j = 0; j < recall_num; j++) {
-      if (RequestContext::is_killed()) return;
+      if (RequestContext::is_killed_every<256>(j)) return;
       if (recall_idxi[j] < 0) continue;
       float dis = 0;
       if (scope_vecs.Get(j) == nullptr) {
@@ -898,16 +898,14 @@ void GammaIVFPQIndex::search_preassigned(
 #pragma omp barrier
 #pragma omp critical
           {
-            if (!RequestContext::is_killed()) {
-              if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-                faiss::heap_addn<HeapForIP>(recall_num, recall_simi, recall_idxi,
-                                          local_dis.data(), local_idx.data(),
-                                          recall_num);
-              } else {
-                faiss::heap_addn<HeapForL2>(recall_num, recall_simi, recall_idxi,
-                                          local_dis.data(), local_idx.data(),
-                                          recall_num);
-              }
+            if (metric_type == faiss::METRIC_INNER_PRODUCT) {
+              faiss::heap_addn<HeapForIP>(recall_num, recall_simi, recall_idxi,
+                                        local_dis.data(), local_idx.data(),
+                                        recall_num);
+            } else {
+              faiss::heap_addn<HeapForL2>(recall_num, recall_simi, recall_idxi,
+                                        local_dis.data(), local_idx.data(),
+                                        recall_num);
             }
           }
 #pragma omp barrier

--- a/internal/engine/index/impl/gamma_index_ivfpq.h
+++ b/internal/engine/index/impl/gamma_index_ivfpq.h
@@ -924,7 +924,7 @@ struct GammaIVFPQScanner : IVFPQScannerT<idx_t, METRIC_TYPE, PQCodeDist>,
   void scan_list_with_table(size_t ncode, const uint8_t *codes,
                             SearchResultType &res) const {
     for (size_t j = 0; j < ncode; j++) {
-      if (RequestContext::is_killed()) {
+      if (RequestContext::is_killed_every<1024>(j)) {
         return;
       }
       if (res.ids[j] & realtime::kDelIdxMask) {

--- a/internal/engine/index/impl/gamma_index_ivfrabitq.cc
+++ b/internal/engine/index/impl/gamma_index_ivfrabitq.cc
@@ -562,7 +562,7 @@ void compute_dis(int k, const float *xi, float *simi, idx_t *idxi,
     }
     int raw_d = vec->MetaInfo()->Dimension();
     for (int j = 0; j < recall_num; j++) {
-      if (RequestContext::is_killed()) return;
+      if (RequestContext::is_killed_every<256>(j)) return;
       if (recall_idxi[j] < 0) continue;
       float dis = 0;
       if (scope_vecs.Get(j) == nullptr) {
@@ -765,16 +765,14 @@ void GammaIVFRABITQIndex::search_preassigned(RetrievalContext *retrieval_context
 #pragma omp barrier
 #pragma omp critical
           {
-            if (!RequestContext::is_killed()) {
-              if (metric_type == faiss::METRIC_INNER_PRODUCT) {
-                faiss::heap_addn<HeapForIP>(recall_num, recall_simi, recall_idxi,
-                                          local_dis.data(), local_idx.data(),
-                                          recall_num);
-              } else {
-                faiss::heap_addn<HeapForL2>(recall_num, recall_simi, recall_idxi,
-                                          local_dis.data(), local_idx.data(),
-                                          recall_num);
-              }
+            if (metric_type == faiss::METRIC_INNER_PRODUCT) {
+              faiss::heap_addn<HeapForIP>(recall_num, recall_simi, recall_idxi,
+                                        local_dis.data(), local_idx.data(),
+                                        recall_num);
+            } else {
+              faiss::heap_addn<HeapForL2>(recall_num, recall_simi, recall_idxi,
+                                        local_dis.data(), local_idx.data(),
+                                        recall_num);
             }
           }
 #pragma omp barrier

--- a/internal/engine/index/impl/hnswlib/gamma_index_hnswlib.cc
+++ b/internal/engine/index/impl/hnswlib/gamma_index_hnswlib.cc
@@ -408,7 +408,7 @@ int GammaIndexHNSWLIB::Search(RetrievalContext *retrieval_context, int n,
 
     if (retrieval_params->GetDistanceComputeType() ==
         DistanceComputeType::INNER_PRODUCT) {
-      while (!result.empty() && !RequestContext::is_killed()) {
+      while (!result.empty()) {
         auto &top = result.top();
         idxs[i * k + k - j - 1] = top.second;
         distances[i * k + k - j - 1] = 1 - top.first;
@@ -416,7 +416,7 @@ int GammaIndexHNSWLIB::Search(RetrievalContext *retrieval_context, int n,
         result.pop();
       }
     } else {
-      while (!result.empty() && !RequestContext::is_killed()) {
+      while (!result.empty()) {
         auto &top = result.top();
         idxs[i * k + k - j - 1] = top.second;
         distances[i * k + k - j - 1] = top.first;

--- a/internal/engine/index/impl/hnswlib/hnswalg.h
+++ b/internal/engine/index/impl/hnswlib/hnswalg.h
@@ -333,6 +333,9 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     while (!candidate_set.empty()) {
       std::pair<dist_t, tableint> current_node_pair = candidate_set.top();
 
+      // One kill-check per node expansion: the inner loop below scans at most
+      // maxM0_ neighbors, so this bounds cancellation latency without paying
+      // is_killed() per neighbor.
       if (vearch::RequestContext::is_killed()) {
         break;
       }
@@ -361,9 +364,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 #endif
 
       for (size_t j = 1; j <= size; j++) {
-        if (vearch::RequestContext::is_killed()) {
-          break;
-        }
         int candidate_id = *(data + j);
 //                    if (candidate_id == 0) continue;
 #ifdef USE_SSE
@@ -1213,12 +1213,14 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         metric_hops++;
         metric_distance_computations += size;
 
+        // Per-hop kill-check: this level's neighbor list is bounded by maxM_,
+        // so checking once per expansion (not per neighbor) is enough.
+        if (vearch::RequestContext::is_killed()) {
+          pthread_rwlock_unlock(&shared_mutex_);
+          return result;
+        }
         tableint *datal = (tableint *)(data + 1);
         for (int i = 0; i < size; i++) {
-          if (vearch::RequestContext::is_killed()) {
-            pthread_rwlock_unlock(&shared_mutex_);
-            return result;
-          }
           tableint cand = datal[i];
           if (cand < 0 || cand > max_elements_)
             throw std::runtime_error("cand error");
@@ -1264,9 +1266,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       top_candidates.pop();
     }
     while (top_candidates.size() > 0) {
-      if (vearch::RequestContext::is_killed()) {
-        break;
-      }
       std::pair<dist_t, tableint> rez = top_candidates.top();
       result.push(std::pair<dist_t, labeltype>(rez.first,
                                                getExternalLabel(rez.second)));

--- a/internal/engine/tests/test_request_context.cc
+++ b/internal/engine/tests/test_request_context.cc
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2019 The Gamma Authors.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "c_api/api_data/request_context.h"
+
+namespace test {
+
+using vearch::RequestContext;
+using vearch::RequestStatusCode;
+
+namespace {
+
+constexpr int kCanceled = static_cast<int>(RequestStatusCode::CANCELED);
+constexpr int kMemoryExceed = static_cast<int>(RequestStatusCode::MEMORY_EXCEED);
+constexpr int kRunning = static_cast<int>(RequestStatusCode::Running_1);
+
+// RawData is abstract; a minimal concrete subclass lets us drive a
+// ScopedContext so the no-arg is_killed() has a current request to resolve.
+class TestRawData : public vearch::RawData {
+ public:
+  int Serialize(char **, int *) override { return 0; }
+  void Deserialize(const char *, int) override {}
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Two-arg kill-status map: set / query / delete lifecycle.
+// ---------------------------------------------------------------------------
+TEST(RequestContextTest, KillStatusLifecycle) {
+  const std::string id = "req-lifecycle";
+  const int pid = 3;
+  RequestContext::delete_kill_status(id, pid);  // start from a clean slate
+
+  EXPECT_FALSE(RequestContext::is_killed(id, pid));
+
+  RequestContext::set_kill_status(id, pid, kCanceled);
+  EXPECT_TRUE(RequestContext::is_killed(id, pid));
+
+  // Different (request_id, partition_id) keys are independent.
+  EXPECT_FALSE(RequestContext::is_killed(id, pid + 1));
+  EXPECT_FALSE(RequestContext::is_killed("other", pid));
+
+  RequestContext::delete_kill_status(id, pid);
+  EXPECT_FALSE(RequestContext::is_killed(id, pid));
+}
+
+TEST(RequestContextTest, MemoryExceedCountsAsKilled) {
+  const std::string id = "req-mem";
+  const int pid = 0;
+  RequestContext::set_kill_status(id, pid, kMemoryExceed);
+  EXPECT_TRUE(RequestContext::is_killed(id, pid));
+  RequestContext::delete_kill_status(id, pid);
+}
+
+TEST(RequestContextTest, RunningStatusIsNotKilled) {
+  const std::string id = "req-running";
+  const int pid = 0;
+  // set_kill_status records the entry regardless of reason, but is_killed only
+  // treats CANCELED / MEMORY_EXCEED as killed, so a Running_* reason is not.
+  RequestContext::set_kill_status(id, pid, kRunning);
+  EXPECT_FALSE(RequestContext::is_killed(id, pid));
+  RequestContext::delete_kill_status(id, pid);
+}
+
+// ---------------------------------------------------------------------------
+// No-arg is_killed() resolves through the thread-local ScopedContext.
+// ---------------------------------------------------------------------------
+TEST(RequestContextTest, NoArgIsKilledFalseWithoutContext) {
+  // No ScopedContext is active on this thread, so current_request_ is null.
+  EXPECT_FALSE(RequestContext::is_killed());
+}
+
+TEST(RequestContextTest, NoArgIsKilledUsesScopedContext) {
+  const std::string id = "req-scoped";
+  const int pid = 5;
+  TestRawData req;
+  req.SetRequestId(id);
+
+  {
+    RequestContext::ScopedContext ctx(&req, pid);
+    EXPECT_FALSE(RequestContext::is_killed());  // not killed yet
+    RequestContext::set_kill_status(id, pid, kCanceled);
+    EXPECT_TRUE(RequestContext::is_killed());
+  }
+  // ScopedContext torn down: current_request_ reset, so no longer resolvable.
+  EXPECT_FALSE(RequestContext::is_killed());
+
+  RequestContext::delete_kill_status(id, pid);
+}
+
+// ---------------------------------------------------------------------------
+// is_killed_every<Stride>(): the amortized hot-loop kill-check.
+// ---------------------------------------------------------------------------
+TEST(RequestContextTest, IsKilledEveryGatesByStride) {
+  const std::string id = "req-stride";
+  const int pid = 1;
+  TestRawData req;
+  req.SetRequestId(id);
+  RequestContext::ScopedContext ctx(&req, pid);
+  RequestContext::set_kill_status(id, pid, kCanceled);
+
+  // At a stride boundary (i % Stride == 0, including i == 0) the kill is seen.
+  EXPECT_TRUE(RequestContext::is_killed_every<1024>(0));
+  EXPECT_TRUE(RequestContext::is_killed_every<1024>(1024));
+  EXPECT_TRUE(RequestContext::is_killed_every<1024>(2048));
+  EXPECT_TRUE(RequestContext::is_killed_every<512>(512));
+  EXPECT_TRUE(RequestContext::is_killed_every<256>(256));
+
+  // Off boundary: gated out, returns false even though the request is killed.
+  EXPECT_FALSE(RequestContext::is_killed_every<1024>(1));
+  EXPECT_FALSE(RequestContext::is_killed_every<1024>(1023));
+  EXPECT_FALSE(RequestContext::is_killed_every<1024>(1025));
+  EXPECT_FALSE(RequestContext::is_killed_every<512>(256));  // 256 % 512 != 0
+  EXPECT_FALSE(RequestContext::is_killed_every<256>(255));
+
+  RequestContext::delete_kill_status(id, pid);
+}
+
+TEST(RequestContextTest, IsKilledEveryFalseWhenNotKilled) {
+  const std::string id = "req-stride-alive";
+  const int pid = 2;
+  TestRawData req;
+  req.SetRequestId(id);
+  RequestContext::ScopedContext ctx(&req, pid);
+  RequestContext::delete_kill_status(id, pid);  // ensure not killed
+
+  // Even at a stride boundary, an un-killed request is never reported killed.
+  EXPECT_FALSE(RequestContext::is_killed_every<1024>(0));
+  EXPECT_FALSE(RequestContext::is_killed_every<1024>(1024));
+}
+
+}  // namespace test
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
* refactor(engine): centralize amortized kill-check into is_killed_every<Stride>()
* perf(ivfrabitq): reduce is_killed() checks on search hot path
* perf(binaryivf): reduce is_killed() checks on search hot path
* perf(ivfflat): reduce is_killed() checks on search hot path
* perf(ivfpq): reduce is_killed() checks on search hot path
* perf(hnsw): reduce is_killed() checks on search hot path
* test(engine): add unit tests for RequestContext kill-check
* style(engine): drop redundant call-site comments for is_killed_every<>()