### PR TITLE
perf: batch field reads via MultiGet and batch is_killed() checks in …

### DIFF
--- a/internal/engine/c_api/api_data/response.cc
+++ b/internal/engine/c_api/api_data/response.cc
@@ -20,6 +20,171 @@
 
 namespace vearch {
 
+namespace {
+
+// Result of reading every scalar field of a batch of result docs in one
+// MultiGet. A fixed-type field is stored in the doc's packed row
+// (ToRowKey(docid)); each string field is its own key (field+":"+ToRowKey).
+struct ScalarBatchResult {
+  // False when no scalar field was requested (only vector fields, or none),
+  // in which case the batched read is skipped and this struct is unused.
+  bool valid = false;
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+  std::vector<rocksdb::Status> statuses;
+  // Every doc queues the same keys in the same order: an optional packed-row
+  // key (present iff has_fixed_field) followed by one key per string field.
+  // A doc's key window is therefore a pure function of its index, so no
+  // per-doc offset table is stored -- FillScalarFromBatch derives the offsets.
+  bool has_fixed_field = false;
+  int num_string_fields = 0;
+};
+
+int SerializeToOut(const vearchpb::SearchResponse &pbResponse, char **out,
+                   int *out_len) {
+  std::string serialized;
+  if (!pbResponse.SerializeToString(&serialized)) {
+    LOG(ERROR) << "failed to serialize results";
+    return -1;
+  }
+  *out_len = serialized.size();
+  *out = (char *)malloc(*out_len * sizeof(char));
+  if (*out == nullptr) {
+    LOG(ERROR) << "failed to allocate memory for response";
+    return -1;
+  }
+  memcpy(*out, serialized.data(), *out_len * sizeof(char));
+  return 0;
+}
+
+// Classify requested scalar fields and read every rocksdb key they need
+// (packed row + one key per string field) in a single MultiGet.
+ScalarBatchResult ReadScalarBatch(Table *table,
+                                  const std::map<std::string, int> &attr_idx,
+                                  GammaResult *gamma_results, int req_num) {
+  ScalarBatchResult batch;
+  std::vector<std::pair<std::string, int>> string_fields;  // name, field_id
+  string_fields.reserve(attr_idx.size());
+  const auto &attrs = table->Attrs();
+  for (auto &it : attr_idx) {
+    DataType dt = attrs[it.second];
+    if (dt == DataType::STRING || dt == DataType::STRINGARRAY) {
+      string_fields.emplace_back(it.first, it.second);
+    } else {
+      batch.has_fixed_field = true;
+    }
+  }
+  if (!batch.has_fixed_field && string_fields.empty()) {
+    return batch;
+  }
+
+  batch.valid = true;
+  batch.num_string_fields = string_fields.size();
+  int total = 0;
+  for (int i = 0; i < req_num; ++i) {
+    total += gamma_results[i].results_count;
+  }
+  batch.keys.reserve(total *
+                     (string_fields.size() + (batch.has_fixed_field ? 1 : 0)));
+  for (int i = 0; i < req_num; ++i) {
+    for (int j = 0; j < gamma_results[i].results_count; ++j) {
+      int docid = gamma_results[i].docs[j]->docid;
+      if (batch.has_fixed_field) {
+        batch.keys.emplace_back(utils::ToRowKey(docid));
+      }
+      for (auto &sf : string_fields) {
+        batch.keys.emplace_back(utils::ToStringFieldKey(sf.first, docid));
+      }
+    }
+  }
+  batch.statuses = table->GetStorageMgr()->MultiGetByKeys(
+      table->CfId(), batch.keys, batch.values);
+  return batch;
+}
+
+// Fast path for the common "return only _id" query: when the id cache is on
+// and _id is the sole requested field, serve it from the in-memory
+// docid->key map and skip rocksdb entirely (no MultiGet, no packed-row
+// decode). Falls back to a storage read only on a cache miss.
+int FillKeyField(vearchpb::ResultItem *item, Table *table,
+                 std::map<std::string, int> &attr_idx, int docid) {
+  const auto &doc_id_map = table->DocidMap();
+  if (auto it = doc_id_map.find(docid); it != doc_id_map.end()) {
+    auto *field = item->add_fields();
+    field->set_name(table->GetKeyFieldName());
+    field->set_value(it->second);
+    return 0;
+  }
+  std::vector<uint8_t> val;
+  int field_id = attr_idx[table->GetKeyFieldName()];
+  int ret = table->GetFieldRawValue(docid, field_id, val, val);
+  if (ret) {
+    return ret;
+  }
+  auto *field = item->add_fields();
+  field->set_name(table->GetKeyFieldName());
+  field->set_value(std::string(val.begin(), val.end()));
+  return 0;
+}
+
+// Fill scalar fields from the batched MultiGet results. Returns 1 when any
+// requested field cannot be read (fixed-type packed row missing, or a string
+// field key missing), so the caller drops the whole doc instead of returning
+// it with some fields silently blanked out.
+int FillScalarFromBatch(vearchpb::ResultItem *item, Table *table,
+                        const std::map<std::string, int> &attr_idx,
+                        ScalarBatchResult &batch, size_t doc_idx) {
+  // Each doc occupies a fixed-width window in keys/values/statuses: an
+  // optional packed-row key, then one key per string field. Derive the
+  // window from doc_idx rather than storing per-doc offsets.
+  size_t stride = (batch.has_fixed_field ? 1 : 0) + batch.num_string_fields;
+  size_t base = doc_idx * stride;
+  const std::string *row_value = nullptr;
+  if (batch.has_fixed_field && batch.statuses[base].ok()) {
+    row_value = &batch.values[base];
+  }
+  size_t str_off = base + (batch.has_fixed_field ? 1 : 0);
+  size_t str_idx = 0;
+  for (auto &it : attr_idx) {
+    int field_id = it.second;
+    DataType dt = table->Attrs()[field_id];
+    auto *field = item->add_fields();
+    field->set_name(it.first);
+    if (dt == DataType::STRING || dt == DataType::STRINGARRAY) {
+      size_t idx = str_off + str_idx;
+      ++str_idx;
+      if (!batch.statuses[idx].ok()) {
+        return 1;
+      }
+      field->set_value(std::move(batch.values[idx]));
+    } else if (row_value) {
+      size_t offset = table->FieldOffset(field_id);
+      int len = Table::FTypeSize(dt);
+      field->set_value(row_value->data() + offset, len);
+    } else {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int FillVectorFields(vearchpb::ResultItem *item, VectorManager *vector_mgr,
+                     std::vector<std::string> &vec_fields, int docid) {
+  for (uint32_t k = 0; k < vec_fields.size(); ++k) {
+    std::vector<uint8_t> vec;
+    int ret = vector_mgr->GetDocVector(docid, vec_fields[k], vec);
+    if (ret) {
+      return ret;
+    }
+    auto *field = item->add_fields();
+    field->set_name(vec_fields[k]);
+    field->set_value(std::string(vec.begin(), vec.end()));
+  }
+  return 0;
+}
+
+}  // namespace
+
 Response::Response() {
   response_ = nullptr;
   perf_tool_ = new PerfTool();
@@ -55,19 +220,7 @@ int Response::Serialize(const std::string &space_name,
 
   // empty result
   if (table == nullptr || vector_mgr == nullptr) {
-    std::string serialized;
-    if (!pbResponse.SerializeToString(&serialized)) {
-      LOG(ERROR) << "failed to serialize empty result";
-      return -1;
-    }
-    *out_len = serialized.size();
-    *out = (char *)malloc(*out_len * sizeof(char));
-    if (*out == nullptr) {
-      LOG(ERROR) << "failed to allocate memory for response";
-      return -1;
-    }
-    memcpy(*out, serialized.data(), *out_len * sizeof(char));
-    return 0;
+    return SerializeToOut(pbResponse, out, out_len);
   }
   const auto &attr_idx_map = table->FieldMap();
 
@@ -87,10 +240,27 @@ int Response::Serialize(const std::string &space_name,
     attr_idx = attr_idx_map;
   }
 
-  const auto &doc_id_map = table->DocidMap();
+  // Fast path: when only _id is requested and the id cache is on, every doc's
+  // _id comes from the in-memory docid->key map, so the whole response can
+  // skip the rocksdb MultiGet below. This is the hot case for search queries
+  // that return just ids, so it is worth special-casing.
+  bool id_cache_fast_path = table->GetEnableIdCache() &&
+                            fields_name.size() == 1 &&
+                            fields_name[0] == table->GetKeyFieldName();
+
+  ScalarBatchResult batch;
+  if (!id_cache_fast_path) {
+    batch = ReadScalarBatch(table, attr_idx, gamma_results_, req_num_);
+  }
+
+  size_t doc_idx = 0;
   for (int i = 0; i < req_num_; ++i) {
     auto *pbRes = pbResponse.add_results();
     vearchpb::SearchStatus *search_status = new vearchpb::SearchStatus();
+    // successful/failed are query-level counts (total hits for this request),
+    // not per-item counts of result_items. result_items is topK-capped and may
+    // shrink further when a doc's field read fails, so its size intentionally
+    // differs from successful; the router merges these as partition-level sums.
     search_status->set_total(gamma_results_[i].total);
     search_status->set_msg("");
     search_status->set_successful(gamma_results_[i].total);
@@ -98,62 +268,40 @@ int Response::Serialize(const std::string &space_name,
     pbRes->set_allocated_status(search_status);
 
     double max_score = std::numeric_limits<double>::lowest();
+    if (RequestContext::is_killed()) {
+      status = Status::MemoryExceeded();
+      return -1;
+    }
     for (int j = 0; j < gamma_results_[i].results_count; ++j) {
-      if (RequestContext::is_killed()) {
-        status = Status::MemoryExceeded();
-        return -1;
-      }
       VectorDoc *vec_doc = gamma_results_[i].docs[j];
       int docid = vec_doc->docid;
       double score = vec_doc->score;
 
       auto *item = pbRes->add_result_items();
       item->set_score(score);
-      max_score = std::max(max_score, score);
 
-      int ret = 0;
-      if (table->GetEnableIdCache() && fields_name.size() == 1 && fields_name[0] == table->GetKeyFieldName()) {
-        if (auto it = doc_id_map.find(docid); it != doc_id_map.end()) {
-          auto *field = item->add_fields();
-          field->set_name(table->GetKeyFieldName());
-          field->set_value(it->second);
-        } else {
-          std::vector<uint8_t> val;
-          int feild_id = attr_idx[table->GetKeyFieldName()];
-          ret = table->GetFieldRawValue(docid, feild_id, val, val);
-          if (ret) {
-            break;
-          }
-          auto *field = item->add_fields();
-          field->set_name(table->GetKeyFieldName());
-          field->set_value(std::string(val.begin(), val.end()));
-        }
+      // Each doc is judged independently: if any of its scalar or vector
+      // fields fails to read, that doc is removed from the response; the rest
+      // of the batch and the overall request still succeed.
+      bool failed = false;
+      if (id_cache_fast_path) {
+        failed = FillKeyField(item, table, attr_idx, docid) != 0;
       } else {
-        std::vector<uint8_t> raw_val;
-
-        for (auto &it : attr_idx) {
-          std::vector<uint8_t> val;
-          ret = table->GetFieldRawValue(docid, it.second, val, raw_val);
-          if (ret) {
-            break;
-          }
-          auto *field = item->add_fields();
-          field->set_name(it.first);
-          field->set_value(std::string(val.begin(), val.end()));
+        // batch.valid is false only when no scalar field was requested, in
+        // which case attr_idx is empty and there is nothing to fill here.
+        if (batch.valid) {
+          failed = FillScalarFromBatch(item, table, attr_idx, batch, doc_idx);
+          ++doc_idx;
         }
-        for (uint32_t k = 0; k < vec_fields.size(); ++k) {
-          std::vector<uint8_t> vec;
-          ret = vector_mgr->GetDocVector(docid, vec_fields[k], vec);
-          if (ret) {
-            break;
-          }
-          auto *field = item->add_fields();
-          field->set_name(vec_fields[k]);
-          field->set_value(std::string(vec.begin(), vec.end()));
+        if (!failed && !vec_fields.empty() &&
+            FillVectorFields(item, vector_mgr, vec_fields, docid)) {
+          failed = true;
         }
-        if (ret) {
-          item->set_score(std::numeric_limits<double>::lowest());
-        }
+      }
+      if (failed) {
+        pbRes->mutable_result_items()->RemoveLast();
+      } else {
+        max_score = std::max(max_score, score);
       }
     }
 
@@ -163,18 +311,9 @@ int Response::Serialize(const std::string &space_name,
     pbRes->set_timeout(false);
   }
 
-  std::string serialized;
-  if (!pbResponse.SerializeToString(&serialized)) {
-    LOG(ERROR) << "failed to serialize results";
+  if (SerializeToOut(pbResponse, out, out_len)) {
     return -1;
   }
-  *out_len = serialized.size();
-  *out = (char *)malloc(*out_len * sizeof(char));
-  if (*out == nullptr) {
-    LOG(ERROR) << "failed to allocate memory for response";
-    return -1;
-  }
-  memcpy(*out, serialized.data(), *out_len * sizeof(char));
   if (perf_tool_) {
     PerfTool *perf_tool = static_cast<PerfTool *>(perf_tool_);
     perf_tool->Perf("serialize");

--- a/internal/engine/storage/storage_manager.cc
+++ b/internal/engine/storage/storage_manager.cc
@@ -12,6 +12,8 @@
 #include <rocksdb/utilities/checkpoint.h>
 
 #include <sstream>
+#include <algorithm>
+#include <numeric>
 
 #include "util/log.h"
 #include "util/utils.h"
@@ -256,8 +258,7 @@ Status StorageManager::Add(int cf_id, int64_t id, const uint8_t *value,
 
 Status StorageManager::AddString(int cf_id, int64_t id, std::string field_name,
                                  const char *value, int len) {
-  std::string key_str = utils::ToRowKey(id);
-  key_str = field_name + ":" + key_str;
+  std::string key_str = utils::ToStringFieldKey(field_name, id);
 
   rocksdb::Status s =
       db_->Put(rocksdb::WriteOptions(), cf_handles_[cf_id],
@@ -311,8 +312,7 @@ Status StorageManager::Delete(int cf_id, const std::string &key) {
 
 Status StorageManager::DeleteString(int cf_id, int64_t id,
                                     std::string field_name) {
-  std::string key_str = utils::ToRowKey(id);
-  key_str = field_name + ":" + key_str;
+  std::string key_str = utils::ToStringFieldKey(field_name, id);
 
   rocksdb::WriteOptions write_options;
   rocksdb::Status s = db_->Delete(write_options, cf_handles_[cf_id], key_str);
@@ -371,8 +371,7 @@ Status StorageManager::Get(int cf_id, const std::string &key,
 
 Status StorageManager::GetString(int cf_id, int64_t id, std::string &field_name,
                                  std::string &value) {
-  std::string key_str = utils::ToRowKey(id);
-  key_str = field_name + ":" + key_str;
+  std::string key_str = utils::ToStringFieldKey(field_name, id);
 
   rocksdb::Status s = db_->Get(rocksdb::ReadOptions(), cf_handles_[cf_id],
                                rocksdb::Slice(key_str), &value);
@@ -389,23 +388,52 @@ std::vector<rocksdb::Status> StorageManager::MultiGet(
     int cf_id, const std::vector<int64_t> &vids,
     std::vector<std::string> &values) {
   size_t k = vids.size();
-  std::vector<rocksdb::Slice> keys;
   std::vector<std::string> keys_data(k);
-  std::vector<rocksdb::ColumnFamilyHandle *> column_families;
-  keys.reserve(k);
-  column_families.reserve(k);
-
   for (size_t i = 0; i < k; i++) {
-    if (RequestContext::is_killed()) {
-      return {};
-    }
     keys_data[i] = utils::ToRowKey(vids[i]);
-    keys.emplace_back(std::move(keys_data[i]));
-    column_families.emplace_back(cf_handles_[cf_id]);
+  }
+  return MultiGetByKeys(cf_id, keys_data, values);
+}
+
+std::vector<rocksdb::Status> StorageManager::MultiGetByKeys(
+    int cf_id, const std::vector<std::string> &keys,
+    std::vector<std::string> &values) {
+  // Sorts keys by std::string operator< (bytewise) and passes
+  // sorted_input=true to db_->MultiGet. This is correct only while the CF uses
+  // the default BytewiseComparator; if a custom comparator is ever configured
+  // for this CF, the sort order would diverge and MultiGet could return wrong
+  // results. values/statuses are returned de-permuted back to input order.
+  size_t k = keys.size();
+  if (k == 0) {
+    values.clear();
+    return {};
+  }
+  std::vector<size_t> order(k);
+  std::iota(order.begin(), order.end(), 0);
+  std::sort(order.begin(), order.end(),
+            [&](size_t a, size_t b) { return keys[a] < keys[b]; });
+
+  std::vector<rocksdb::Slice> sorted_keys(k);
+  for (size_t i = 0; i < k; i++) {
+    sorted_keys[i] = rocksdb::Slice(keys[order[i]]);
   }
 
-  std::vector<rocksdb::Status> statuses =
-      db_->MultiGet(rocksdb::ReadOptions(), column_families, keys, &values);
+  std::vector<rocksdb::PinnableSlice> sorted_values(k);
+  std::vector<rocksdb::Status> sorted_statuses(k);
+  rocksdb::ReadOptions ro;
+  db_->MultiGet(ro, cf_handles_[cf_id], k, sorted_keys.data(),
+                sorted_values.data(), sorted_statuses.data(),
+                true /*sorted_input*/);
+
+  values.assign(k, std::string());
+  std::vector<rocksdb::Status> statuses(k);
+  for (size_t i = 0; i < k; i++) {
+    size_t orig = order[i];
+    if (sorted_statuses[i].ok()) {
+      values[orig].assign(sorted_values[i].data(), sorted_values[i].size());
+    }
+    statuses[orig] = std::move(sorted_statuses[i]);
+  }
   return statuses;
 }
 

--- a/internal/engine/storage/storage_manager.h
+++ b/internal/engine/storage/storage_manager.h
@@ -49,6 +49,13 @@ class StorageManager {
                                         const std::vector<int64_t> &vids,
                                         std::vector<std::string> &values);
 
+  // Batch read by arbitrary string keys in one column family. Keys do NOT
+  // need to be sorted - this helper sorts internally and passes
+  // sorted_input=true to rocksdb so each SST is opened at most once.
+  std::vector<rocksdb::Status> MultiGetByKeys(
+      int cf_id, const std::vector<std::string> &keys,
+      std::vector<std::string> &values);
+
   std::unique_ptr<rocksdb::Iterator> NewIterator(int cf_id) {
     return std::unique_ptr<rocksdb::Iterator>(
         db_->NewIterator(rocksdb::ReadOptions(), cf_handles_[cf_id]));

--- a/internal/engine/table/table.h
+++ b/internal/engine/table/table.h
@@ -160,6 +160,12 @@ class Table {
   bool GetEnableIdCache() { return enable_id_cache_; }
   void SetEnableIdCache(bool enabled);
 
+  const std::vector<DataType> &Attrs() const { return attrs_; }
+  size_t FieldOffset(int field_id) const { return idx_attr_offset_[field_id]; }
+  int CfId() const { return cf_id_; }
+  StorageManager *GetStorageMgr() const { return storage_mgr_; }
+  static int FTypeSize(DataType fType);
+
   DumpConfig *GetDumpConfig() { return table_params_; }
 
   int64_t GetStorageManagerSize();
@@ -169,8 +175,6 @@ class Table {
   int64_t last_docid_;
 
  private:
-  int FTypeSize(DataType fType);
-
   Status AddField(const std::string &name, DataType ftype, bool is_index);
 
   std::string name_;   // table name

--- a/internal/engine/tests/test_utils.cc
+++ b/internal/engine/tests/test_utils.cc
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2019 The Gamma Authors.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "storage/storage_manager.h"
+#include "util/utils.h"
+
+namespace test {
+
+// ---- utils::ToStringFieldKey -------------------------------------------------
+// Pure function: "<field_name>:<ToRowKey(id)>". Read and write paths must
+// produce byte-identical keys, so pin the exact format here.
+
+TEST(ToStringFieldKey, Format) {
+  EXPECT_EQ(utils::ToStringFieldKey("name", 42),
+            "name:" + utils::ToRowKey(42));
+  // ToRowKey zero-pads to 10 digits; keep this contract explicit.
+  EXPECT_EQ(utils::ToStringFieldKey("name", 42), "name:0000000042");
+  EXPECT_EQ(utils::ToStringFieldKey("name", 0), "name:0000000000");
+}
+
+TEST(ToStringFieldKey, EmptyFieldName) {
+  EXPECT_EQ(utils::ToStringFieldKey("", 7), ":0000000007");
+}
+
+// ---- StorageManager::MultiGetByKeys -----------------------------------------
+// The helper sorts keys internally, passes sorted_input=true to rocksdb, then
+// de-permutes values/statuses back to the caller's original key order. These
+// tests exercise that reorder-restore logic without any vector dataset.
+
+class MultiGetByKeysTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = std::string("test_multiget_") +
+            ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    utils::remove_dir(root_.c_str());
+    mgr_ = new vearch::StorageManager(root_);
+    cf_id_ = mgr_->CreateColumnFamily("scalar");
+    ASSERT_TRUE(mgr_->Init(0).ok());
+  }
+
+  void TearDown() override {
+    mgr_->Close();
+    delete mgr_;
+    utils::remove_dir(root_.c_str());
+  }
+
+  void Put(const std::string &key, const std::string &value) {
+    std::string v = value;
+    ASSERT_TRUE(mgr_->Put(cf_id_, key, v).ok());
+  }
+
+  std::string root_;
+  int cf_id_ = 0;
+  vearch::StorageManager *mgr_ = nullptr;
+};
+
+TEST_F(MultiGetByKeysTest, RestoresInputOrderForUnsortedKeys) {
+  Put("b", "vb");
+  Put("a", "va");
+  Put("c", "vc");
+
+  // Deliberately unsorted request order.
+  std::vector<std::string> keys = {"c", "a", "b"};
+  std::vector<std::string> values;
+  auto statuses = mgr_->MultiGetByKeys(cf_id_, keys, values);
+
+  ASSERT_EQ(values.size(), keys.size());
+  ASSERT_EQ(statuses.size(), keys.size());
+  EXPECT_TRUE(statuses[0].ok());
+  EXPECT_TRUE(statuses[1].ok());
+  EXPECT_TRUE(statuses[2].ok());
+  // Values must line up with the original (unsorted) key positions.
+  EXPECT_EQ(values[0], "vc");
+  EXPECT_EQ(values[1], "va");
+  EXPECT_EQ(values[2], "vb");
+}
+
+TEST_F(MultiGetByKeysTest, DuplicateKeysGetIndependentSlots) {
+  Put("k", "vk");
+
+  std::vector<std::string> keys = {"k", "k", "k"};
+  std::vector<std::string> values;
+  auto statuses = mgr_->MultiGetByKeys(cf_id_, keys, values);
+
+  ASSERT_EQ(values.size(), 3u);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_TRUE(statuses[i].ok());
+    EXPECT_EQ(values[i], "vk");
+  }
+}
+
+TEST_F(MultiGetByKeysTest, MissingKeysMapToNotFoundStatus) {
+  Put("present1", "v1");
+  Put("present2", "v2");
+
+  std::vector<std::string> keys = {"missing_a", "present2", "missing_b",
+                                    "present1"};
+  std::vector<std::string> values;
+  auto statuses = mgr_->MultiGetByKeys(cf_id_, keys, values);
+
+  ASSERT_EQ(values.size(), keys.size());
+  ASSERT_EQ(statuses.size(), keys.size());
+  // Status/value must map back to each key's original slot, not the sorted one.
+  EXPECT_FALSE(statuses[0].ok());
+  EXPECT_TRUE(statuses[1].ok());
+  EXPECT_EQ(values[1], "v2");
+  EXPECT_FALSE(statuses[2].ok());
+  EXPECT_TRUE(statuses[3].ok());
+  EXPECT_EQ(values[3], "v1");
+}
+
+TEST_F(MultiGetByKeysTest, EmptyInput) {
+  std::vector<std::string> keys;
+  std::vector<std::string> values;
+  auto statuses = mgr_->MultiGetByKeys(cf_id_, keys, values);
+  EXPECT_TRUE(values.empty());
+  EXPECT_TRUE(statuses.empty());
+}
+
+}  // namespace test

--- a/internal/engine/util/utils.cc
+++ b/internal/engine/util/utils.cc
@@ -520,6 +520,10 @@ std::string ToRowKey(int32_t key) {
   return key_str;
 }
 
+std::string ToStringFieldKey(const std::string &field_name, int32_t id) {
+  return field_name + ":" + ToRowKey(id);
+}
+
 int64_t FromRowKey64(const std::string &key) {
   if (key.size() != sizeof(int64_t)) {
     return -1;

--- a/internal/engine/util/utils.h
+++ b/internal/engine/util/utils.h
@@ -199,6 +199,12 @@ struct ScopeDeleter1 {
 std::string ToRowKey64(int64_t key);
 std::string ToRowKey(int32_t key);
 
+// Storage key for a single string-typed field of a doc:
+// "<field_name>:<ToRowKey(id)>". Fixed-type fields live in the doc's packed row
+// (ToRowKey alone); each string field is stored under its own key in this
+// format. Read and write paths must agree on it, so keep it in one place.
+std::string ToStringFieldKey(const std::string &field_name, int32_t id);
+
 int64_t FromRowKey64(const std::string &key);
 int32_t FromRowKey(const std::string &key);
 

--- a/internal/engine/vector/vector_manager.cc
+++ b/internal/engine/vector/vector_manager.cc
@@ -719,10 +719,10 @@ int ParseSearchResult(int n, int k, VectorResult &result, IndexModel *index) {
   for (int i = 0; i < n; i++) {
     int pos = 0;
     std::map<int, int> docid2count;
+    if (RequestContext::is_killed()) {
+      return -2;
+    }
     for (int j = 0; j < k; j++) {
-      if (RequestContext::is_killed()) {
-        return -2;
-      }
       int64_t *docid = result.docids + i * k + j;
       if (docid[0] == -1) continue;
       int vector_id = (int)docid[0];


### PR DESCRIPTION
…Response::Serialize (#809)

* refactor: split Response::Serialize into focused helpers
* refactor: extract ToStringFieldKey helper for string-field storage keys
* perf: batch field reads via MultiGet and batch is_killed() checks in Response::Serialize
* fix: drop the whole doc when any scalar field read fails
* test: add unit tests for ToStringFieldKey and MultiGetByKeys